### PR TITLE
Add algebraic data types

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -45,12 +45,13 @@ check program = void $ mapM check1 (properties program)
       do putStr $ "testing:" ++ name ++ "> "
          iter numberOfTests
       where
-        config   = ([], [], declarations program)
-        genParts = mapM strengthen $ second (generateGenerator config) <$> args
-        term     = uncurry $ foldr (\(x, v) t -> substitute x t v)
-        eval     = normalize program
-        iter 0   = putStrLn " ok"
-        iter n   =
+        dataDecls = dataDeclarations program
+        config    = ([], [], declarations program)
+        genParts  = mapM strengthen $ second (generateGenerator dataDecls config) <$> args
+        term      = uncurry $ foldr (\(x, v) t -> substitute x t v)
+        eval      = normalize program
+        iter 0    = putStrLn " ok"
+        iter n    =
           do parts <- generate genParts
              test  <- term <$> return (body, parts)
              case eval test of

--- a/pun-lang.cabal
+++ b/pun-lang.cabal
@@ -24,6 +24,7 @@ source-repository head
 
 library
   exposed-modules:
+      Environment
       GeneratorGenerator
       Interpreter
       Parser

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -1,0 +1,87 @@
+module Environment where
+
+import Syntax
+
+import           Control.Arrow
+import qualified Control.Monad.RWS as RWS
+
+
+-- * Program Environment
+
+-- Definition
+data Environment m a =
+  Environment
+    { function      :: F -> m (Term a)
+    , definitionsIn :: [(Name, Term a)]
+    , datatype      :: C -> m D
+    , fieldTypes    :: C -> m [Type]
+    , constructors  :: D -> m [TypeConstructor]
+    }
+
+-- Implementation
+programEnvironment :: Monad m => Program a -> Environment m a
+programEnvironment p =
+  Environment
+    { function = \f ->
+        case lookup f (definitions p) of
+          Just def -> return def
+          Nothing  -> error $
+            "Couldn't find definition for function '" ++ f ++ "'"
+    , definitionsIn = definitions p
+    , datatype = \c ->
+        case lookup c (typeConstructorNames p) of
+          Just  d -> return d
+          Nothing -> error $
+            "Couldn't find data type declaration for constructor '" ++ c ++ "'"
+    , fieldTypes   = \c ->
+        case lookup c (typeConstructorFields p) of
+          Just ts -> return ts
+          Nothing -> error $ "Couldn't find constructor with name '" ++ c ++ "'"
+    , constructors = \d ->
+        case lookup d (dataDeclarations p) of
+          Just cs -> return cs
+          Nothing -> error $ "Couldn't find data type with name '" ++ d ++ "'"
+    }
+
+-- * Environment Reader Writer State monad
+newtype ERWS e r w s a =
+  ERWS { coERWS :: RWS.RWS (Environment (ERWS e r w s) e, r) w s a }
+
+instance Monoid w => Monad (ERWS e r w s) where
+  return  = pure
+  m >>= f = ERWS $ coERWS m >>= coERWS . f
+
+instance Monoid w => Applicative (ERWS e r w s) where
+  pure = ERWS . RWS.return
+  e0 <*> e1 = e0 >>= \f -> f <$> e1
+
+instance Monoid w => Functor (ERWS e r w s) where
+  fmap f = ERWS . fmap f . coERWS
+
+runERWS :: Monoid w => ERWS e r w s a -> Program e -> r -> s -> (a, s, w)
+runERWS erws p r = RWS.runRWS (coERWS erws) (programEnvironment p, r)
+
+-- Environment
+environment :: Monoid w => ERWS e r w s (Environment (ERWS e r w s) e)
+environment = ERWS $ fst <$> RWS.ask
+
+-- Reader
+local :: Monoid w => (r -> r) -> (ERWS e r w s b -> ERWS e r w s b)
+local f = ERWS . RWS.local (second f) . coERWS
+
+ask :: Monoid w => ERWS e r w s r
+ask = ERWS $ snd <$> RWS.ask
+
+-- Writer
+tell :: Monoid w => w -> ERWS e r w s ()
+tell = ERWS . RWS.tell
+
+-- State
+put :: Monoid w => s -> ERWS e r w s ()
+put = ERWS . RWS.put
+
+get :: Monoid w => ERWS e r w s s
+get = ERWS RWS.get
+
+modify :: Monoid w => (s -> s) -> ERWS e r w s ()
+modify f = ERWS $ RWS.modify f

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -11,11 +11,11 @@ import qualified Control.Monad.RWS as RWS
 -- Definition
 data Environment m a =
   Environment
-    { function      :: F -> m (Term a)
-    , definitionsIn :: [(Name, Term a)]
-    , datatype      :: C -> m D
-    , fieldTypes    :: C -> m [Type]
-    , constructors  :: D -> m [TypeConstructor]
+    { function       :: F -> m (Term a)
+    , definitionsIn  :: [(Name, Term a)]
+    , datatype       :: C -> m D
+    , fieldTypes     :: C -> m [Type]
+    , constructorsOf :: D -> m [TypeConstructor]
     }
 
 -- Implementation
@@ -37,7 +37,7 @@ programEnvironment p =
         case lookup c (typeConstructorFields p) of
           Just ts -> return ts
           Nothing -> error $ "Couldn't find constructor with name '" ++ c ++ "'"
-    , constructors = \d ->
+    , constructorsOf = \d ->
         case lookup d (dataDeclarations p) of
           Just cs -> return cs
           Nothing -> error $ "Couldn't find data type with name '" ++ d ++ "'"

--- a/src/GeneratorGenerator.hs
+++ b/src/GeneratorGenerator.hs
@@ -109,6 +109,12 @@ generateGeneratorSized ds s bst@(BST type1 type2) size =
              return $ Node l k v r bst
         , return $ Leaf (BST type1 type2)
         ]
+generateGeneratorSized ds s (Algebraic d) size =
+  oneof (map ctrGen (constructors ds d))
+  where
+    ctrGen (TypeConstructor c types) =
+      do ts <- mapM (\tau -> generateGeneratorSized ds s tau (decrease size)) types
+         return $ Constructor c ts (Algebraic d)
 
 resolve :: Index -> LocalIndices -> Type
 resolve i is =

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -56,6 +56,9 @@ interpret (Node l k v r a) =
      v' <- interpret v
      r' <- interpret r
      return $ Node l' k' v' r' a
+interpret (Constructor c ts a) =
+  do ts' <- mapM interpret ts
+     return $ Constructor c ts' a
 interpret (Case t0 l (p, n) _) =
   do v <- interpret t0
      case v of

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -112,7 +112,7 @@ term_ =
   , pre "\\" $ Lambda <$> name <*> pre "->" term_
   , pre "let" $ Let <$> name <*> pre "=" term_ <*> pre "in" term_
   , pre "rec" $ Rec <$> name <*> pre "." term_
-  , Constructor <$> constructorName <*> (option [] (brackets (sepBy term_ (symbol ","))))
+  , Constructor <$> constructorName <*> (option [] $ brackets $ term_ `sepBy` symbol ",")
   ]
   where
     lift1 op t1 t2 = op t1 t2 (fst $ annotation t1, snd $ annotation t2)
@@ -120,10 +120,10 @@ term_ =
     add            = pre  "+" $ return $ lift1 Plus
     app            = return $ lift1 Application
 
-constructorName :: Parser (Name)
+constructorName :: Parser Name
 constructorName = lexeme $ (:) <$> upper <*> many letter
 
-typeConstructor :: Parser (TypeConstructor)
+typeConstructor :: Parser TypeConstructor
 typeConstructor = 
   do 
     c  <- constructorName

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -112,7 +112,7 @@ term_ =
   , pre "\\" $ Lambda <$> name <*> pre "->" term_
   , pre "let" $ Let <$> name <*> pre "=" term_ <*> pre "in" term_
   , pre "rec" $ Rec <$> name <*> pre "." term_
-  , Constructor <$> constructorName <*> (option [] $ brackets $ term_ `sepBy` symbol ",")
+  , Constructor <$> constructorName <*> option [] (brackets $ term_ `sepBy` symbol ",")
   ]
   where
     lift1 op t1 t2 = op t1 t2 (fst $ annotation t1, snd $ annotation t2)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -95,6 +95,11 @@ instance Annotated Term where
   annotations (Case  t0 l (p, n) a) = a : ([t0, l, p, n] >>= annotations)
   annotation  term                  = head $ annotations term
 
+
+-- Utility functions
+swap :: (a, b) -> (b, a)
+swap (a, b) = (b, a)
+
 putParens :: String -> String
 putParens = ("(" ++) . (++ ")")
 
@@ -152,6 +157,20 @@ dataDeclarations (Definition  _ _  rest) = dataDeclarations rest
 dataDeclarations (Declaration _ _  rest) = dataDeclarations rest
 dataDeclarations (Property  _ _ _  rest) = dataDeclarations rest
 dataDeclarations _                       = mempty
+
+typeConstructors :: Program a -> [(TypeConstructor, D)]
+typeConstructors p = concatMap (fromConstructor . swap) (dataDeclarations p)
+  where
+    fromConstructor :: ([TypeConstructor], D) -> [(TypeConstructor, D)]
+    fromConstructor (ctrs, t) = [ (c, t) | c <- ctrs ]
+
+typeConstructorNames :: Program a -> [(C, D)]
+typeConstructorNames p = map (\(TypeConstructor c _, t) -> (c, t)) (typeConstructors p)
+
+typeConstructorFields :: Program a -> [(C, [Type])]
+typeConstructorFields p = map (\(TypeConstructor c ts) -> (c, ts)) constructors
+  where
+    constructors = map fst (typeConstructors p)
 
 definitions :: Program a -> [(F, Term a)]
 definitions (Data        d ts rest) = definitions rest

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -2,6 +2,8 @@
 
 module Syntax where
 
+import Data.List (intercalate)
+
 -- Abbreviations.
 type Name        = String
 type F           = Name
@@ -110,6 +112,7 @@ instance Show (Term a) where
   show (Number  n         _) = show n
   show (Boolean b         _) = show b
   show (Unit              _) = "unit"
+  show (Constructor c ts  _) = show c ++ " [" ++ intercalate ", " (map show ts) ++ "]"
   show (Leaf              _) = "leaf"
   show (Node l k v r      _) = "[node " ++ show l ++ show k ++ show v ++ show r ++ "]"
   show (Case t l (p, n)   _) =

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -190,6 +190,8 @@ freeVariables (Number _ _) = mempty
 freeVariables (Boolean _ _) = mempty
 freeVariables (Unit      _) = mempty
 freeVariables (Leaf      _) = mempty
+freeVariables (Constructor _ ts _) =
+  foldr (\t fvs -> fvs <> freeVariables t) mempty ts
 freeVariables (Node l k v r _) =
      freeVariables l
   <> freeVariables k

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -168,15 +168,15 @@ properties (Declaration _ _  rest) = properties rest
 properties (Property  p x t  rest) = (p, (x, t)) : properties rest
 properties _                       = mempty
 
-indicies :: Type -> [Index]
-indicies (Variable' a)  = [a]
-indicies  Integer'      = []
-indicies  Boolean'      = []
-indicies  Unit'         = []
-indicies (t1 :*:   t2)  = indicies t1 <> indicies t2
-indicies (t1 :->:  t2)  = indicies t1 <> indicies t2
-indicies (BST   t1 t2)  = indicies t1 <> indicies t2
-indicies (Algebraic d)  = []
+indices :: Type -> [Index]
+indices (Variable' a)  = [a]
+indices  Integer'      = []
+indices  Boolean'      = []
+indices  Unit'         = []
+indices (t1 :*:   t2)  = indices t1 <> indices t2
+indices (t1 :->:  t2)  = indices t1 <> indices t2
+indices (BST   t1 t2)  = indices t1 <> indices t2
+indices (Algebraic d)  = []
 
 instance Semigroup (Program a) where
   (Declaration x t p1) <> p2 = Declaration x  t (p1 <> p2)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -112,7 +112,7 @@ instance Show (Term a) where
   show (Number  n         _) = show n
   show (Boolean b         _) = show b
   show (Unit              _) = "unit"
-  show (Constructor c ts  _) = show c ++ " [" ++ intercalate ", " (map show ts) ++ "]"
+  show (Constructor c ts  _) = c ++ " [" ++ intercalate ", " (map show ts) ++ "]"
   show (Leaf              _) = "leaf"
   show (Node l k v r      _) = "[node " ++ show l ++ show k ++ show v ++ show r ++ "]"
   show (Case t l (p, n)   _) =

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -99,6 +99,8 @@ putParens :: String -> String
 putParens = ("(" ++) . (++ ")")
 
 instance Show a => Show (Program a) where
+  show (Data d taus rest) =
+    "data " ++ d ++ " = " ++ show taus ++ "\n\n" ++ show rest
   show (Declaration x t rest) =
     x ++ " :: " ++ show t ++ "\n\n" ++ show rest
   show (Definition x t rest) =
@@ -106,6 +108,10 @@ instance Show a => Show (Program a) where
   show (Property p xs t rest) =
     "property " ++ p ++ " " ++ show xs ++ " . " ++ show t ++ "\n\n" ++ show rest
   show EndOfProgram = ""
+
+instance Show TypeConstructor where
+  show (TypeConstructor c []) = c
+  show (TypeConstructor c cs) = c ++ " (" ++ intercalate ", " (map show cs) ++ ")"
 
 instance Show (Term a) where
   -- todo (minimally bracketed printer + tests) --

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -173,6 +173,7 @@ indicies  Unit'         = []
 indicies (t1 :*:   t2)  = indicies t1 <> indicies t2
 indicies (t1 :->:  t2)  = indicies t1 <> indicies t2
 indicies (BST   t1 t2)  = indicies t1 <> indicies t2
+indicies (Algebraic d)  = []
 
 instance Semigroup (Program a) where
   (Declaration x t p1) <> p2 = Declaration x  t (p1 <> p2)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -77,6 +77,7 @@ instance Annotated Term where
   annotations (Boolean         _ a) = return a
   annotations (Variable        _ a) = return a
   annotations (Unit              a) = return a
+  annotations (Constructor _ ts  a) = a : (ts           >>= annotations)
   annotations (If       t0 t1 t2 a) = a : ([t0, t1, t2] >>= annotations)
   annotations (Plus     t0 t1    a) = a : ([t0, t1]     >>= annotations)
   annotations (Leq      t0 t1    a) = a : ([t0, t1]     >>= annotations)
@@ -88,7 +89,7 @@ instance Annotated Term where
   annotations (Lambda _ t0       a) = a : annotations t0
   annotations (Rec    _ t0       a) = a : annotations t0
   annotations (Leaf              a) = return a
-  annotations (Node      l k v r a) = a : ([l, k, v, r]    >>= annotations)
+  annotations (Node      l k v r a) = a : ([l, k, v, r]  >>= annotations)
   annotations (Case  t0 l (p, n) a) = a : ([t0, l, p, n] >>= annotations)
   annotation  term                  = head $ annotations term
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -126,14 +126,15 @@ instance Show (Term a) where
   show (Rec x t0          _) = "rec " ++ x ++ " . " ++ show t0
 
 canonical :: Term a -> Bool
-canonical (Number  _     _) = True
-canonical (Boolean _     _) = True
-canonical (Unit          _) = True
-canonical (Pair    t1 t2 _) = canonical t1 && canonical t2
-canonical (Lambda  {}     ) = True
-canonical (Leaf          _) = True
-canonical (Node   l k v r _) = all canonical [l, k, v, r]
-canonical _                 = False
+canonical (Number  _        _) = True
+canonical (Boolean _        _) = True
+canonical (Unit             _) = True
+canonical (Constructor _ ts _) = all canonical ts
+canonical (Pair    t1 t2    _) = canonical t1 && canonical t2
+canonical (Lambda  {}        ) = True
+canonical (Leaf             _) = True
+canonical (Node   l k v r   _) = all canonical [l, k, v, r]
+canonical _                    = False
 
 dataDeclarations :: Program a -> [(D, [TypeConstructor])]
 dataDeclarations (Data        d ts rest) = (d, ts) : dataDeclarations rest

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -185,10 +185,11 @@ indices (BST   t1 t2)  = indices t1 <> indices t2
 indices (Algebraic d)  = []
 
 instance Semigroup (Program a) where
-  (Declaration x t p1) <> p2 = Declaration x  t (p1 <> p2)
-  (Definition  x t p1) <> p2 = Definition  x  t (p1 <> p2)
-  (Property p xs t p1) <> p2 = Property  p xs t (p1 <> p2)
-  EndOfProgram         <> p2 = p2
+  (Data        d ts p1) <> p2 = Data        d ts (p1 <> p2)
+  (Declaration x t  p1) <> p2 = Declaration x  t (p1 <> p2)
+  (Definition  x t  p1) <> p2 = Definition  x  t (p1 <> p2)
+  (Property p xs t  p1) <> p2 = Property  p xs t (p1 <> p2)
+  EndOfProgram          <> p2 = p2
 
 instance Monoid (Program a) where
   mempty  = EndOfProgram

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -173,35 +173,35 @@ typeConstructorFields p = map (\(TypeConstructor c ts) -> (c, ts)) constructors
     constructors = map fst (typeConstructors p)
 
 definitions :: Program a -> [(F, Term a)]
-definitions (Data        d ts rest) = definitions rest
-definitions (Definition  x t  rest) = (x, t) : definitions rest
-definitions (Declaration _ _  rest) = definitions rest
-definitions (Property  _ _ _  rest) = definitions rest
-definitions _                       = mempty
+definitions (Data        _ _ rest) = definitions rest
+definitions (Definition  x t rest) = (x, t) : definitions rest
+definitions (Declaration _ _ rest) = definitions rest
+definitions (Property  _ _ _ rest) = definitions rest
+definitions _                      = mempty
 
 declarations :: Program a -> [(X, Type)]
-declarations (Data        d ts rest) = declarations rest
-declarations (Definition  _ _  rest) = declarations rest
-declarations (Declaration x t  rest) = (x, t) : declarations rest
-declarations (Property  _ _ _  rest) = declarations rest
-declarations _                       = mempty
+declarations (Data        _ _ rest) = declarations rest
+declarations (Definition  _ _ rest) = declarations rest
+declarations (Declaration x t rest) = (x, t) : declarations rest
+declarations (Property  _ _ _ rest) = declarations rest
+declarations _                      = mempty
 
 properties :: Program a -> [(P, ([(X, a)], Term a))]
-properties (Data        d ts rest) = properties rest
-properties (Definition  _ _  rest) = properties rest
-properties (Declaration _ _  rest) = properties rest
-properties (Property  p x t  rest) = (p, (x, t)) : properties rest
-properties _                       = mempty
+properties (Data        _ _ rest) = properties rest
+properties (Definition  _ _ rest) = properties rest
+properties (Declaration _ _ rest) = properties rest
+properties (Property  p x t rest) = (p, (x, t)) : properties rest
+properties _                      = mempty
 
 indices :: Type -> [Index]
-indices (Variable' a)  = [a]
-indices  Integer'      = []
-indices  Boolean'      = []
-indices  Unit'         = []
-indices (t1 :*:   t2)  = indices t1 <> indices t2
-indices (t1 :->:  t2)  = indices t1 <> indices t2
-indices (BST   t1 t2)  = indices t1 <> indices t2
-indices (Algebraic d)  = []
+indices (Variable' a) = [a]
+indices  Integer'     = []
+indices  Boolean'     = []
+indices  Unit'        = []
+indices (t1 :*:   t2) = indices t1 <> indices t2
+indices (t1 :->:  t2) = indices t1 <> indices t2
+indices (BST   t1 t2) = indices t1 <> indices t2
+indices (Algebraic _) = []
 
 instance Semigroup (Program a) where
   (Data        d ts p1) <> p2 = Data        d ts (p1 <> p2)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -135,23 +135,33 @@ canonical (Leaf          _) = True
 canonical (Node   l k v r _) = all canonical [l, k, v, r]
 canonical _                 = False
 
+dataDeclarations :: Program a -> [(D, [TypeConstructor])]
+dataDeclarations (Data        d ts rest) = (d, ts) : dataDeclarations rest
+dataDeclarations (Definition  _ _  rest) = dataDeclarations rest
+dataDeclarations (Declaration _ _  rest) = dataDeclarations rest
+dataDeclarations (Property  _ _ _  rest) = dataDeclarations rest
+dataDeclarations _                       = mempty
+
 definitions :: Program a -> [(F, Term a)]
-definitions (Definition  x t rest) = (x, t) : definitions rest
-definitions (Declaration _ _ rest) = definitions rest
-definitions (Property  _ _ _ rest) = definitions rest
-definitions _                      = mempty
+definitions (Data        d ts rest) = definitions rest
+definitions (Definition  x t  rest) = (x, t) : definitions rest
+definitions (Declaration _ _  rest) = definitions rest
+definitions (Property  _ _ _  rest) = definitions rest
+definitions _                       = mempty
 
 declarations :: Program a -> [(X, Type)]
-declarations (Definition  _ _ rest) = declarations rest
-declarations (Declaration x t rest) = (x, t) : declarations rest
-declarations (Property  _ _ _ rest) = declarations rest
-declarations _                      = mempty
+declarations (Data        d ts rest) = declarations rest
+declarations (Definition  _ _  rest) = declarations rest
+declarations (Declaration x t  rest) = (x, t) : declarations rest
+declarations (Property  _ _ _  rest) = declarations rest
+declarations _                       = mempty
 
 properties :: Program a -> [(P, ([(X, a)], Term a))]
-properties (Definition  _ _ rest) = properties rest
-properties (Declaration _ _ rest) = properties rest
-properties (Property  p x t rest) = (p, (x, t)) : properties rest
-properties _                      = mempty
+properties (Data        d ts rest) = properties rest
+properties (Definition  _ _  rest) = properties rest
+properties (Declaration _ _  rest) = properties rest
+properties (Property  p x t  rest) = (p, (x, t)) : properties rest
+properties _                       = mempty
 
 indicies :: Type -> [Index]
 indicies (Variable' a)  = [a]

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -258,8 +258,9 @@ freeVariables (Rec x t0 _) = [ y | y <- freeVariables t0 , x /= y ]
 
 -- /!\ optimisation : declarations can be thrown away at runtime to make the program smaller.
 withoutDeclarations :: Program a -> Program a
-withoutDeclarations (Declaration _ _ p)  =                     withoutDeclarations p
-withoutDeclarations (Definition  x t p)  = Definition   x  t $ withoutDeclarations p
+withoutDeclarations (Declaration _ _  p) =                     withoutDeclarations p
+withoutDeclarations (Data        d ts p) = Data         d ts $ withoutDeclarations p
+withoutDeclarations (Definition  x t  p) = Definition   x  t $ withoutDeclarations p
 withoutDeclarations (Property  n xs t p) = Property   n xs t $ withoutDeclarations p
 withoutDeclarations EndOfProgram         = EndOfProgram
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -7,6 +7,7 @@ type Name        = String
 type F           = Name
 type X           = Name
 type C           = Name
+type D           = Name
 type P           = Name
 type Index       = Integer
 type T0        a = Term a
@@ -24,11 +25,15 @@ type Pattern   a = Term a
 type Canonical a = Term a
 
 data Program a
-  = Declaration X           Type    (Program a)
+  = Data        D [TypeConstructor] (Program a)
+  | Declaration X           Type    (Program a)
   | Definition  F          (Term a) (Program a)
   | Property    P [(X, a)] (Term a) (Program a)
   | EndOfProgram
   deriving (Functor, Eq)
+
+data TypeConstructor = TypeConstructor C [Type]
+  deriving Eq
 
 data Type
   = Variable' Index
@@ -37,6 +42,7 @@ data Type
   | Unit'
   | Type :*: Type
   | Type :->: Type
+  | Algebraic D
   | BST Key Value
   deriving (Eq, Show)
 
@@ -45,6 +51,7 @@ data Term a =
   | Boolean   Bool                      a
   | Unit                                a
   | Leaf                                a
+  | Constructor C [Term a]              a
   | Node (Left a) (K a) (V a) (Right a) a
   | Case (T0 a) (Leaf a) (Node a)       a
   | Variable  Name                      a

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -215,7 +215,7 @@ instance Monoid (Program a) where
   mappend = (<>)
 
 freeVariables :: Term a -> [Name]
-freeVariables (Number _ _) = mempty
+freeVariables (Number  _ _) = mempty
 freeVariables (Boolean _ _) = mempty
 freeVariables (Unit      _) = mempty
 freeVariables (Leaf      _) = mempty

--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -191,6 +191,14 @@ alpha i t = (if null (indices t) then i else i + maximum (indices t) + 1, increm
         increment (t1 :->: t2 )   = increment t1 :->: increment t2
         increment (BST key value) = BST (increment key) (increment value)
 
+alphaADT :: Index -> [TypeConstructor] -> (Index, [TypeConstructor])
+alphaADT i = foldr (\c (j, k) -> second (: k) (alphaDef j c)) (i, [])
+
+alphaDef :: Index -> TypeConstructor -> (Index, TypeConstructor)
+alphaDef i (TypeConstructor c cs) = second (TypeConstructor c)
+                                    (foldr (\t (j, ts) ->
+                                              second (: ts) (alpha j t)) (i, []) cs)
+
 -- TODO: Better error handling {^o^}!
 bindings :: [Constraint] -> Substitution
 bindings = fromMaybe (error "type error") . solve

--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -42,6 +42,13 @@ annotate (Unit       _)  = return $ Unit Unit'
 annotate (Variable x _)  =
   do env <- ask
      return $ Variable x $ env x
+annotate (Constructor c ts _) =
+  do vs   <- mapM annotate ts
+     env  <- environment
+     adt  <- datatype env c
+     taus <- fieldTypes env c
+     vs `haveTypes` taus
+     return $ Constructor c vs (Algebraic adt)
 annotate (If t0 t1 t2 _) =
   do t0' <- annotate t0
      t1' <- annotate t1

--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -228,7 +228,13 @@ inferP program = refine (bindings $ cs ++ cs') <$> pt
                   , (y, t'') <- definitions  pt
                   , x == y
                   ]
-    program'    = inferP' program :: Annotation (Program Type)
+    program' = inferP' program
+    inferP' (Data d taus p) =
+      do i <- get
+         let (j, taus') = alphaADT i taus
+         put j
+         rest' <- local (bind d (Algebraic d)) $ inferP' p
+         return $ Data d taus' rest'
     inferP' (Declaration x t p) =
       do i <- get
          let (j, tau) = alpha i t

--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -168,7 +168,7 @@ infer term = runRWS (annotate term) emptyEnvironment
 
 -- alpha renaming.
 alpha :: Index -> (Type -> (Index, Type))
-alpha i t = (if null (indicies t) then i else i + maximum (indicies t) + 1, increment t)
+alpha i t = (if null (indices t) then i else i + maximum (indices t) + 1, increment t)
   where increment Integer'        = Integer'
         increment Boolean'        = Boolean'
         increment Unit'           = Unit'

--- a/src/Unification.hs
+++ b/src/Unification.hs
@@ -34,10 +34,11 @@ unify' (Node l1 k1 v1 r1 _) (Node l2 k2 v2 r2 _) =
 unify' _ _ = Nothing
 
 isPattern :: Term a -> Bool
-isPattern (Variable    _ _) = True
-isPattern (Node  l k v r _) = all isPattern [l, k, v, r]
-isPattern (Pair  t1 t2   _) = all isPattern [t1, t2]
-isPattern t                 = canonical t
+isPattern (Variable       _ _) = True
+isPattern (Node     l k v r _) = all isPattern [l, k, v, r]
+isPattern (Pair       t1 t2 _) = all isPattern [t1, t2]
+isPattern (Constructor _ ts _) = all isPattern ts
+isPattern t                    = canonical t
 
 contains :: Pattern a -> X -> Bool
 contains (Variable y       _) x = x == y

--- a/src/Unification.hs
+++ b/src/Unification.hs
@@ -40,21 +40,22 @@ isPattern (Pair  t1 t2   _) = all isPattern [t1, t2]
 isPattern t                 = canonical t
 
 contains :: Pattern a -> X -> Bool
-contains (Variable y  _) x = x == y
-contains (If t0 t1 t2 _) x = any (`contains` x) [t0, t1, t2]
-contains (Plus  t0 t1 _) x = t0 `contains` x || t1 `contains` x
-contains (Leq   t0 t1 _) x = t0 `contains` x || t1 `contains` x
-contains (Pair  t0 t1 _) x = t0 `contains` x || t1 `contains` x
-contains (Fst   t0    _) x = t0 `contains` x
-contains (Snd   t0    _) x = t0 `contains` x
-contains (Lambda n t0 _) x = n == x || t0 `contains` x
-contains (Let n t1 t2 _) x =
+contains (Variable y       _) x = x == y
+contains (Constructor _ ts _) x = any (`contains` x) ts
+contains (If t0 t1 t2      _) x = any (`contains` x) [t0, t1, t2]
+contains (Plus  t0 t1      _) x = t0 `contains` x || t1 `contains` x
+contains (Leq   t0 t1      _) x = t0 `contains` x || t1 `contains` x
+contains (Pair  t0 t1      _) x = t0 `contains` x || t1 `contains` x
+contains (Fst   t0         _) x = t0 `contains` x
+contains (Snd   t0         _) x = t0 `contains` x
+contains (Lambda n t0      _) x = n == x || t0 `contains` x
+contains (Let n t1 t2      _) x =
   n   ==        x ||
   t1 `contains` x ||
   t2 `contains` x
-contains (Rec n t0    _) x = n == x || t0 `contains` x
+contains (Rec n t0          _) x = n == x || t0 `contains` x
 contains (Application t1 t2 _) x = t1 `contains` x || t2 `contains` x
-contains _              _ = False
+contains _                     _ = False
 
 substitutes :: Pattern a -> X -> Unifier a
 substitutes p x = return (x, p)

--- a/src/Unification.hs
+++ b/src/Unification.hs
@@ -40,7 +40,7 @@ unify' _ _ = Nothing
 validateUnifiers :: [Maybe (Unifier a)] -> Maybe (Unifier a)
 validateUnifiers us
   | any isNothing us = Nothing
-  | otherwise        = Just $ foldr (mappend . (fromMaybe [])) mempty us
+  | otherwise        = Just $ foldr (mappend . fromMaybe []) mempty us
 
 isPattern :: Term a -> Bool
 isPattern (Variable       _ _) = True

--- a/test/GeneratorGeneratorTests.hs
+++ b/test/GeneratorGeneratorTests.hs
@@ -13,7 +13,7 @@ newtype Primitive
 
 instance Arbitrary Primitive where
   arbitrary =
-    Primitive <$> oneof (generateGenerator ([], [], []) <$> [Integer', Boolean'])
+    Primitive <$> oneof (generateGenerator [] ([], [], []) <$> [Integer', Boolean'])
 
 newtype TerminatingTerm
     = TerminatingTerm (Term Type, Type)
@@ -22,7 +22,7 @@ newtype TerminatingTerm
 instance Arbitrary TerminatingTerm where
   arbitrary =
     do t    <- aType
-       term <- generateGenerator mempty t
+       term <- generateGenerator mempty mempty t
        return $ TerminatingTerm (term, t)
 
 newtype SubstType = SubstType (Substitution, Type, Term Type, Type)
@@ -33,7 +33,7 @@ instance Arbitrary SubstType where
     do subs  <- generateSubstitution
        t     <- generateType subs []
        let canonT = refine subs t
-       term  <- generateGenerator (subs, [], []) canonT
+       term  <- generateGenerator mempty (subs, [], []) canonT
        return $ SubstType (subs, t, term, canonT)
 
 newtype AcyclicIndices = AcyclicIndices LocalIndices
@@ -52,7 +52,7 @@ newtype AnalyseGenerator = AnalyseGenerator (Term Type, ([String], [String]))
 instance Arbitrary AnalyseGenerator where
   arbitrary =
     do t    <- aType
-       term <- generateGenerator mempty t
+       term <- generateGenerator mempty mempty t
        return $ AnalyseGenerator (term, analyse term)
 
 generateGeneratorTests :: TestTree

--- a/test/GeneratorGeneratorTests.hs
+++ b/test/GeneratorGeneratorTests.hs
@@ -73,7 +73,7 @@ generateGeneratorTests =
         equivalent t typeOfT',
     testProperty "Only valid types are generated from a substitution." $
     \(SubstType (subs, t, _, _)) ->
-      all (`elem` (fst <$> subs)) (indicies t),
+      all (`elem` (fst <$> subs)) (indices t),
     testProperty "generateGenerator generates appropriate type for generated substitution." $
     \(SubstType (_, _, term, canonT)) ->
       let (t', _, cs) = infer term 0
@@ -168,9 +168,9 @@ unifiesWith Boolean' Boolean' = return []
 unifiesWith Unit'    Unit'    = return []
 unifiesWith (Variable' a) (Variable' b) = return [(a, Variable' b)]
 unifiesWith (Variable' a) t             =
-  if a `elem` indicies t then Nothing else return [(a, t)]
+  if a `elem` indices t then Nothing else return [(a, t)]
 unifiesWith t             (Variable' b) =
-  if b `elem` indicies t then Nothing else return [(b, t)]
+  if b `elem` indices t then Nothing else return [(b, t)]
 unifiesWith (t1 :*: t2)  (ta :*: tb) =
   do a1 <-          t1 `unifiesWith` ta
      b2 <- subst a1 t2 `unifiesWith` subst a1 tb

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -103,49 +103,49 @@ termParserTests_positive =
   , ("if 5 <= 7 then 0 else true",
      If (Leq (Number 5 ()) (Number 7 ()) ()) (Number 0 ()) (Boolean True ()) ()
     )
-  , ("[node leaf 3 5 leaf]",
-       Node (Leaf ()) (Number 3 ()) (Number 5 ()) (Leaf ()) ())
-  , ("[node [ node leaf 3 5 leaf] 4 (true, ~4) leaf]",
-      Node
-        (Node (Leaf ()) (Number 3 ()) (Number 5 ()) (Leaf ()) ())
-        (Number 4 ())
-        (Pair (Boolean True ()) (Number (-4) ()) ())
-        (Leaf ()) ())
-  , ("\\x -> \\f -> \\y -> f x y"
-    , (Lambda "x"
-         (Lambda "f"
-            (Lambda "y"
-               (Application
-                  (Application (Variable "f" ()) (Variable "x" ()) ())
-                (Variable "y" ()) ()) ()) ()) ()
-      )
-    )
-  , ("case t of"   ++
-     "; leaf -> 5" ++
-     "; [node l1 true true [node l2 false false r2]] -> f l1 l2 r2"
-    , Case (Variable "t" ())
-      -- leaf -->
-        (Number 5 ())
-      (Node
-         (Variable "l1" ())
-         (Boolean True ())
-         (Boolean True ())
-         (Node (Variable "l2" ()) (Boolean False ()) (Boolean False ()) (Variable "r2" ()) ()) () ,
-      -- node -->
-       Application
-         (Application
-            (Application (Variable "f" ()) (Variable "l1" ()) ())
-               (Variable "l2" ()) ())
-         (Variable "r2" ()) ()) ())
+--  , ("[node leaf 3 5 leaf]",
+--       Node (Leaf ()) (Number 3 ()) (Number 5 ()) (Leaf ()) ())
+--  , ("[node [ node leaf 3 5 leaf] 4 (true, ~4) leaf]",
+--      Node
+--        (Node (Leaf ()) (Number 3 ()) (Number 5 ()) (Leaf ()) ())
+--        (Number 4 ())
+--        (Pair (Boolean True ()) (Number (-4) ()) ())
+--        (Leaf ()) ())
+--  , ("\\x -> \\f -> \\y -> f x y"
+--    , (Lambda "x"
+--         (Lambda "f"
+--            (Lambda "y"
+--               (Application
+--                  (Application (Variable "f" ()) (Variable "x" ()) ())
+--                (Variable "y" ()) ()) ()) ()) ()
+--      )
+--    )
+--  , ("case t of"   ++
+--     "; leaf -> 5" ++
+--     "; [node l1 true true [node l2 false false r2]] -> f l1 l2 r2"
+--    , Case (Variable "t" ())
+--      -- leaf -->
+--        (Number 5 ())
+--      (Node
+--         (Variable "l1" ())
+--         (Boolean True ())
+--         (Boolean True ())
+--         (Node (Variable "l2" ()) (Boolean False ()) (Boolean False ()) (Variable "r2" ()) ()) () ,
+--      -- node -->
+--       Application
+--         (Application
+--            (Application (Variable "f" ()) (Variable "l1" ()) ())
+--               (Variable "l2" ()) ())
+--         (Variable "r2" ()) ()) ())
   ]
 
 termParserTests_negative :: [TestTree]
 termParserTests_negative =
-  map (\s -> testCase ("'" ++ s ++ "'") $ negative term_ s)
-  [ ""
-  , "(true , )"
-  , "[node leaf]"
-  , " false"
+ map (\s -> testCase ("'" ++ s ++ "'") $ negative term_ s)
+ [ ""
+ , "(true , )"
+ , "[node leaf]"
+ , " false"
   ]
 
 parseProgramsFromFiles :: [TestTree]
@@ -209,339 +209,339 @@ parseProgramsFromFiles =
               (Application (Variable "less" ()) (Variable "m" ()) ())
               (Variable "n" ()) ()) ()) ()) ()) $
        EndOfProgram)
-    , ("examples/insert.pun",
-        Declaration "equal" (Integer' :->: (Integer' :->: Boolean')) $
-        Definition "equal" (Lambda "m" (Lambda "n"
-        (If (Leq (Variable "m" ()) (Variable "n" ()) ())
-            (Leq (Variable "n" ()) (Variable "m" ()) ())
-            (Boolean False ()) ()) ()) ()) $
-        Declaration "not" (Boolean' :->: Boolean') $
-        Definition  "not" (Lambda "b"
-          (If (Variable "b"  ())
-              (Boolean False ())
-              (Boolean True  ()) ()) ()) $
-        Declaration "and" (Boolean' :->: (Boolean' :->: Boolean')) $
-        Definition  "and" (Lambda "b1" (Lambda "b2"
-        (If (Variable "b1" ())
-            (Variable "b2" ())
-            (Boolean False ()) ()) ()) ()) $
-        Declaration "less" (Integer' :->: (Integer' :->: Boolean')) $
-        Definition  "less" (Lambda "m" (Lambda "n"
-        (Application
-        (Application
-          (Variable "and" ())
-          (Leq (Variable "m" ()) (Variable "n" ()) ()) ())
-        (Application
-          (Variable "not" ())
-          (Application
-            (Application (Variable "equal" ()) (Variable "m" ()) ())
-            (Variable "n" ()) ()) ()) ()) ()) ()) $
-        Declaration "insert" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
-        Definition  "insert" (Lambda "k1" (Lambda "v1" (Lambda "t"
-        (Case
-          (Variable "t" ())
-          (Node (Leaf ()) (Variable "k1" ()) (Variable "v1" ()) (Leaf ()) ())
-          (Node (Variable "l" ()) (Variable "k2" ()) (Variable "v2" ()) (Variable "r" ()) (),
-          If (Application (Application (Variable "equal" ()) (Variable "k1" ()) ()) (Variable "k2" ()) ())
-             (Node (Variable "l" ()) (Variable "k2" ()) (Variable "v1" ()) (Variable "r" ()) ())
-             (If (Leq (Variable "k1" ()) (Variable "k2" ()) ())
-                 (Node (Application
-                          (Application
-                            (Application
-                              (Variable "insert" ())
-                              (Variable "k1" ()) ())
-                            (Variable "v1" ()) ())
-                          (Variable "l" ()) ())
-                      (Variable "k2" ())
-                      (Variable "v2" ())
-                      (Variable "r" ()) ())
-                  (If (Application
-                      (Application
-                        (Variable "larger" ())
-                        (Variable "k1" ()) ())
-                      (Variable "k2" ()) ())
-                    (Node (Variable "l" ())
-                          (Variable "k2" ())
-                          (Variable "v2" ())
-                          (Application
-                            (Application
-                              (Application
-                                (Variable "insert" ())
-                                (Variable "k1" ()) ())
-                              (Variable "v1" ()) ())
-                            (Variable "r" ()) ()) ())
-                    (Node (Leaf ()) (Variable "k1" ()) (Variable "v1" ()) (Leaf ()) ()) ()) ()) ()) ()) ()) ()) ()) $
-        EndOfProgram)
-      , ("examples/delete.pun",
-        Declaration "findMin" (BST Integer' Integer' :->: BST Integer' Integer') $
-        Definition  "findMin" (Lambda "t"
-          (Case
-            (Variable "t" ())
-            (Leaf ())
-            (Node (Variable "l" ()) (Variable "k" ()) (Variable "v" ()) (Variable "r" ()) (),
-            Case
-              (Variable "l" ())
-              (Node (Leaf ()) (Variable "k" ()) (Variable "v" ()) (Leaf ()) ())
-              (Node (Variable "l1" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r1" ()) (),
-              Application (Variable "findMin" ()) (Variable "l1" ()) ()) ()) ()) ()) $
-        Declaration "delete" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
-        Definition  "delete" (Lambda "k" (Lambda "v" (Lambda "t"
-          (Case
-            (Variable "t" ())
-            (Leaf ())
-            (Node (Variable "l" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r" ()) (),
-             If (Application
-                  (Application (Variable "less" ()) (Variable "k" ()) ())
-                  (Variable "k1" ()) ())
-                (Node (Application
-                        (Application
-                          (Application
-                            (Variable "delete" ())
-                            (Variable "k" ()) ())
-                          (Variable "v" ()) ())
-                        (Variable "l" ()) ())
-                      (Variable "k1" ())
-                      (Variable "v1" ())
-                      (Variable "r" ()) ())
-                (If (Application
-                      (Application
-                        (Variable "larger" ())
-                        (Variable "k" ()) ())
-                      (Variable "k1" ()) ())
-                    (Node (Variable "l"  ())
-                          (Variable "k1" ())
-                          (Variable "v1" ())
-                          (Application
-                            (Application
-                              (Application
-                                (Variable "delete" ())
-                                (Variable "k" ()) ())
-                              (Variable "v" ()) ())
-                            (Variable "r" ()) ()) ())
-                    (Application
-                      (Application
-                        (Application
-                          (Variable "delete1" ())
-                          (Variable "k1" ()) ())
-                        (Variable "v1" ()) ())
-                      (Variable "t" ()) ()) ()) ()) ()) ()) ()) ()) $
-        Declaration "delete1" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
-        Definition  "delete1" (Lambda "k" (Lambda "v" (Lambda "t"
-          (Case (Variable "t" ())
-                (Leaf ())
-                (Node (Variable "l"  ())
-                      (Variable "k1" ())
-                      (Variable "v1" ())
-                      (Variable "r"  ()) (),
-                 Case (Variable "l"  ())
-                      (Variable "r"  ())
-                      (Node (Variable "l1" ())
-                            (Variable "k2" ())
-                            (Variable "v2" ())
-                            (Variable "r1" ()) (),
-                       Case (Variable "r" ())
-                            (Variable "l" ())
-                            (Node (Variable "l2" ())
-                                  (Variable "k3" ())
-                                  (Variable "v3" ())
-                                  (Variable "r2" ()) (),
-                             Case (Application
-                                    (Variable "findMin" ())
-                                    (Variable "r" ()) ())
-                                  (Leaf ())
-                                  (Node (Leaf ())
-                                        (Variable "minKey" ())
-                                        (Variable "minVal" ())
-                                        (Leaf ()) (),
-                                         Node (Variable "l" ())
-                                              (Variable "minKey" ())
-                                              (Variable "minVal" ())
-                                              (Application
-                                                (Application
-                                                  (Application
-                                                    (Variable "delete" ())
-                                                    (Variable "minKey" ()) ())
-                                                  (Variable "minVal" ()) ())
-                                                (Variable "r" ()) ()) ()) ()) ()) ()) ()) ()) ()) ()) $
-        EndOfProgram)
-      , ("examples/union.pun",
-        Declaration "union" (BST Integer' Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer')) $
-        Definition  "union" (Lambda "t1" (Lambda "t2"
-          (Case (Variable "t2" ())
-                (Variable "t1" ())
-                (Node (Variable "l" ())
-                      (Variable "k" ())
-                      (Variable "v" ())
-                      (Variable "r" ())
-                      (),
-                 Case (Variable "t1" ())
-                      (Variable "t2" ())
-                      (Node (Variable "l1" ())
-                            (Variable "k1" ())
-                            (Variable "v1" ())
-                            (Variable "r1" ()) (),
-                       Application
-                        (Application
-                          (Variable "union" ())
-                          (Application
-                            (Application
-                              (Application
-                                (Variable "delete" ())
-                                (Variable "k1"     ()) ())
-                              (Variable "v1" ()) ())
-                            (Variable "t1" ()) ()) ())
-                          (Application
-                            (Application
-                              (Application
-                                (Variable "insert" ())
-                                (Variable "k1"     ()) ())
-                              (Variable "v1" ()) ())
-                            (Variable "t2" ()) ()) ()) ()) ()) ()) ()) $
-        EndOfProgram)
-      , ("examples/find.pun",
-        Declaration "find" (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer')) $
-        Definition  "find" (Lambda "k" (Lambda "t"
-          (Case
-            (Variable "t" ())
-            (Leaf ())
-            (Node (Variable "l"  ())
-                  (Variable "k1" ())
-                  (Variable "v"  ())
-                  (Variable "r" ()) (),
-             If (Application
-                  (Application (Variable "equal" ()) (Variable "k" ()) ())
-                  (Variable "k1" ()) ())
-                (Node (Leaf ()) (Variable "k1" ()) (Variable "v" ()) (Leaf ()) ())
-                (If (Application
-                      (Application (Variable "larger" ()) (Variable "k" ()) ())
-                      (Variable "k1" ()) ())
-                    (Application
-                      (Application (Variable "find" ()) (Variable "k" ()) ())
-                      (Variable "r" ()) ())
-                    (If (Application
-                          (Application (Variable "less" ()) (Variable "k" ()) ())
-                          (Variable "l" ()) ())
-                        (Application
-                          (Application (Variable "find" ()) (Variable "k" ()) ())
-                          (Variable "l" ()) ())
-                        (Leaf ()) ()) ()) ()) ()) ()) ()) $
-        Declaration "findMin" (BST Integer' Integer' :->: BST Integer' Integer') $
-        Definition  "findMin" (Lambda "t"
-          (Case
-            (Variable "t" ())
-            (Leaf ())
-            (Node (Variable "l" ()) (Variable "k" ()) (Variable "v" ()) (Variable "r" ()) (),
-            Case
-              (Variable "l" ())
-              (Node (Leaf ()) (Variable "k" ()) (Variable "v" ()) (Leaf ()) ())
-              (Node (Variable "l1" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r1" ()) (),
-              Application (Variable "findMin" ()) (Variable "l1" ()) ()) ()) ()) ()) $
-        EndOfProgram)
-      , ("examples/bst-properties.pun",
-         Property "find-post-present"
-                  [("k", ()), ("v", ()), ("t", ())]
-                  (Application
-                    (Application
-                      (Variable "equal" ())
-                      (Application
-                        (Application (Variable "find" ()) (Variable "k" ()) ())
-                        (Application
-                          (Application
-                            (Application (Variable "insert" ()) (Variable "k" ()) ())
-                            (Variable "v" ()) ())
-                          (Variable "t" ()) ()) ()) ())
-                      (Node (Leaf ())
-                            (Variable "k" ())
-                            (Variable "v" ())
-                            (Leaf ()) ()) ()) $
-         Property "find-post-absent"
-                   [("k", ()), ("t", ())]
-                   (Application
-                    (Application
-                      (Variable "equal" ())
-                      (Application
-                        (Application
-                          (Variable "find" ())
-                          (Variable "k" ()) ())
-                        (Application
-                          (Application
-                            (Variable "delete" ())
-                            (Variable "k" ()) ())
-                          (Variable "t" ()) ()) ()) ())
-                      (Leaf ()) ()) $
-         Property "insert-delete-complete"
-                  [("k", ()), ("t", ())]
-                  (Case
-                    (Application
-                      (Application
-                        (Variable "find" ())
-                        (Variable "k" ()) ())
-                      (Variable "t" ()) ())
-                    (Application
-                      (Application
-                        (Variable "equal" ())
-                        (Variable "t" ()) ())
-                      (Application
-                        (Application
-                          (Variable "delete" ())
-                          (Variable "k"      ()) ())
-                        (Variable "t" ()) ()) ())
-                      (Node (Variable "l"  ())
-                            (Variable "k1" ())
-                            (Variable "v"  ())
-                            (Variable "r" ()) (),
-                       Application
-                        (Application
-                          (Variable "equal" ())
-                          (Variable "t" ()) ())
-                        (Application
-                          (Application
-                            (Application
-                              (Variable "insert" ())
-                              (Variable "k" ()) ())
-                            (Variable "v" ()) ())
-                          (Variable "t" ()) ()) ()) ()) $
-         Property "insert-post"
-                  [("k", ()), ("v", ()), ("t", ()), ("k1", ())]
-                  (Application
-                    (Application
-                      (Variable "equal" ())
-                      (Application
-                        (Application
-                          (Variable "find" ())
-                          (Variable "k1" ()) ())
-                        (Application
-                          (Application
-                            (Application
-                              (Variable "insert" ())
-                              (Variable "k" ()) ())
-                            (Variable "v" ()) ())
-                          (Variable "t" ()) ()) ()) ())
-                      (If
-                        (Application
-                          (Application
-                            (Variable "equal" ())
-                            (Variable "k" ()) ())
-                          (Variable "k1" ()) ())
-                        (Node (Leaf ())
-                              (Variable "k" ())
-                              (Variable "v" ())
-                              (Leaf ()) ())
-                        (Application
-                          (Application
-                            (Variable "find" ())
-                            (Variable "k1" ()) ())
-                          (Variable "t" ()) ()) ()) ()) $
-         Property "insert-post-same-key"
-                  [("k", ()), ("v", ()), ("t", ())]
-                  (Application
-                    (Application
-                      (Application
-                        (Application (Variable "insert-post" ()) (Variable "k" ()) ())
-                        (Variable "v" ()) ())
-                      (Variable "t" ()) ())
-                    (Variable "k" ()) ()) $
-         EndOfProgram)
+    -- , ("examples/insert.pun",
+    --     Declaration "equal" (Integer' :->: (Integer' :->: Boolean')) $
+    --     Definition "equal" (Lambda "m" (Lambda "n"
+    --     (If (Leq (Variable "m" ()) (Variable "n" ()) ())
+    --         (Leq (Variable "n" ()) (Variable "m" ()) ())
+    --         (Boolean False ()) ()) ()) ()) $
+    --     Declaration "not" (Boolean' :->: Boolean') $
+    --     Definition  "not" (Lambda "b"
+    --       (If (Variable "b"  ())
+    --           (Boolean False ())
+    --           (Boolean True  ()) ()) ()) $
+    --     Declaration "and" (Boolean' :->: (Boolean' :->: Boolean')) $
+    --     Definition  "and" (Lambda "b1" (Lambda "b2"
+    --     (If (Variable "b1" ())
+    --         (Variable "b2" ())
+    --         (Boolean False ()) ()) ()) ()) $
+    --     Declaration "less" (Integer' :->: (Integer' :->: Boolean')) $
+    --     Definition  "less" (Lambda "m" (Lambda "n"
+    --     (Application
+    --     (Application
+    --       (Variable "and" ())
+    --       (Leq (Variable "m" ()) (Variable "n" ()) ()) ())
+    --     (Application
+    --       (Variable "not" ())
+    --       (Application
+    --         (Application (Variable "equal" ()) (Variable "m" ()) ())
+    --         (Variable "n" ()) ()) ()) ()) ()) ()) $
+    --     Declaration "insert" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
+    --     Definition  "insert" (Lambda "k1" (Lambda "v1" (Lambda "t"
+    --     (Case
+    --       (Variable "t" ())
+    --       (Node (Leaf ()) (Variable "k1" ()) (Variable "v1" ()) (Leaf ()) ())
+    --       (Node (Variable "l" ()) (Variable "k2" ()) (Variable "v2" ()) (Variable "r" ()) (),
+    --       If (Application (Application (Variable "equal" ()) (Variable "k1" ()) ()) (Variable "k2" ()) ())
+    --          (Node (Variable "l" ()) (Variable "k2" ()) (Variable "v1" ()) (Variable "r" ()) ())
+    --          (If (Leq (Variable "k1" ()) (Variable "k2" ()) ())
+    --              (Node (Application
+    --                       (Application
+    --                         (Application
+    --                           (Variable "insert" ())
+    --                           (Variable "k1" ()) ())
+    --                         (Variable "v1" ()) ())
+    --                       (Variable "l" ()) ())
+    --                   (Variable "k2" ())
+    --                   (Variable "v2" ())
+    --                   (Variable "r" ()) ())
+    --               (If (Application
+    --                   (Application
+    --                     (Variable "larger" ())
+    --                     (Variable "k1" ()) ())
+    --                   (Variable "k2" ()) ())
+    --                 (Node (Variable "l" ())
+    --                       (Variable "k2" ())
+    --                       (Variable "v2" ())
+    --                       (Application
+    --                         (Application
+    --                           (Application
+    --                             (Variable "insert" ())
+    --                             (Variable "k1" ()) ())
+    --                           (Variable "v1" ()) ())
+    --                         (Variable "r" ()) ()) ())
+    --                 (Node (Leaf ()) (Variable "k1" ()) (Variable "v1" ()) (Leaf ()) ()) ()) ()) ()) ()) ()) ()) ()) $
+    --     EndOfProgram)
+      -- , ("examples/delete.pun",
+      --   Declaration "findMin" (BST Integer' Integer' :->: BST Integer' Integer') $
+      --   Definition  "findMin" (Lambda "t"
+      --     (Case
+      --       (Variable "t" ())
+      --       (Leaf ())
+      --       (Node (Variable "l" ()) (Variable "k" ()) (Variable "v" ()) (Variable "r" ()) (),
+      --       Case
+      --         (Variable "l" ())
+      --         (Node (Leaf ()) (Variable "k" ()) (Variable "v" ()) (Leaf ()) ())
+      --         (Node (Variable "l1" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r1" ()) (),
+      --         Application (Variable "findMin" ()) (Variable "l1" ()) ()) ()) ()) ()) $
+      --   Declaration "delete" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
+      --   Definition  "delete" (Lambda "k" (Lambda "v" (Lambda "t"
+      --     (Case
+      --       (Variable "t" ())
+      --       (Leaf ())
+      --       (Node (Variable "l" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r" ()) (),
+      --        If (Application
+      --             (Application (Variable "less" ()) (Variable "k" ()) ())
+      --             (Variable "k1" ()) ())
+      --           (Node (Application
+      --                   (Application
+      --                     (Application
+      --                       (Variable "delete" ())
+      --                       (Variable "k" ()) ())
+      --                     (Variable "v" ()) ())
+      --                   (Variable "l" ()) ())
+      --                 (Variable "k1" ())
+      --                 (Variable "v1" ())
+      --                 (Variable "r" ()) ())
+      --           (If (Application
+      --                 (Application
+      --                   (Variable "larger" ())
+      --                   (Variable "k" ()) ())
+      --                 (Variable "k1" ()) ())
+      --               (Node (Variable "l"  ())
+      --                     (Variable "k1" ())
+      --                     (Variable "v1" ())
+      --                     (Application
+      --                       (Application
+      --                         (Application
+      --                           (Variable "delete" ())
+      --                           (Variable "k" ()) ())
+      --                         (Variable "v" ()) ())
+      --                       (Variable "r" ()) ()) ())
+      --               (Application
+      --                 (Application
+      --                   (Application
+      --                     (Variable "delete1" ())
+      --                     (Variable "k1" ()) ())
+      --                   (Variable "v1" ()) ())
+      --                 (Variable "t" ()) ()) ()) ()) ()) ()) ()) ()) $
+      --   Declaration "delete1" (Integer' :->: (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer'))) $
+      --   Definition  "delete1" (Lambda "k" (Lambda "v" (Lambda "t"
+      --     (Case (Variable "t" ())
+      --           (Leaf ())
+      --           (Node (Variable "l"  ())
+      --                 (Variable "k1" ())
+      --                 (Variable "v1" ())
+      --                 (Variable "r"  ()) (),
+      --            Case (Variable "l"  ())
+      --                 (Variable "r"  ())
+      --                 (Node (Variable "l1" ())
+      --                       (Variable "k2" ())
+      --                       (Variable "v2" ())
+      --                       (Variable "r1" ()) (),
+      --                  Case (Variable "r" ())
+      --                       (Variable "l" ())
+      --                       (Node (Variable "l2" ())
+      --                             (Variable "k3" ())
+      --                             (Variable "v3" ())
+      --                             (Variable "r2" ()) (),
+      --                        Case (Application
+      --                               (Variable "findMin" ())
+      --                               (Variable "r" ()) ())
+      --                             (Leaf ())
+      --                             (Node (Leaf ())
+      --                                   (Variable "minKey" ())
+      --                                   (Variable "minVal" ())
+      --                                   (Leaf ()) (),
+      --                                    Node (Variable "l" ())
+      --                                         (Variable "minKey" ())
+      --                                         (Variable "minVal" ())
+      --                                         (Application
+      --                                           (Application
+      --                                             (Application
+      --                                               (Variable "delete" ())
+      --                                               (Variable "minKey" ()) ())
+      --                                             (Variable "minVal" ()) ())
+      --                                           (Variable "r" ()) ()) ()) ()) ()) ()) ()) ()) ()) ()) $
+      --   EndOfProgram)
+      -- , ("examples/union.pun",
+      --   Declaration "union" (BST Integer' Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer')) $
+      --   Definition  "union" (Lambda "t1" (Lambda "t2"
+      --     (Case (Variable "t2" ())
+      --           (Variable "t1" ())
+      --           (Node (Variable "l" ())
+      --                 (Variable "k" ())
+      --                 (Variable "v" ())
+      --                 (Variable "r" ())
+      --                 (),
+      --            Case (Variable "t1" ())
+      --                 (Variable "t2" ())
+      --                 (Node (Variable "l1" ())
+      --                       (Variable "k1" ())
+      --                       (Variable "v1" ())
+      --                       (Variable "r1" ()) (),
+      --                  Application
+      --                   (Application
+      --                     (Variable "union" ())
+      --                     (Application
+      --                       (Application
+      --                         (Application
+      --                           (Variable "delete" ())
+      --                           (Variable "k1"     ()) ())
+      --                         (Variable "v1" ()) ())
+      --                       (Variable "t1" ()) ()) ())
+      --                     (Application
+      --                       (Application
+      --                         (Application
+      --                           (Variable "insert" ())
+      --                           (Variable "k1"     ()) ())
+      --                         (Variable "v1" ()) ())
+      --                       (Variable "t2" ()) ()) ()) ()) ()) ()) ()) $
+      --   EndOfProgram)
+      -- , ("examples/find.pun",
+      --   Declaration "find" (Integer' :->: (BST Integer' Integer' :->: BST Integer' Integer')) $
+      --   Definition  "find" (Lambda "k" (Lambda "t"
+      --     (Case
+      --       (Variable "t" ())
+      --       (Leaf ())
+      --       (Node (Variable "l"  ())
+      --             (Variable "k1" ())
+      --             (Variable "v"  ())
+      --             (Variable "r" ()) (),
+      --        If (Application
+      --             (Application (Variable "equal" ()) (Variable "k" ()) ())
+      --             (Variable "k1" ()) ())
+      --           (Node (Leaf ()) (Variable "k1" ()) (Variable "v" ()) (Leaf ()) ())
+      --           (If (Application
+      --                 (Application (Variable "larger" ()) (Variable "k" ()) ())
+      --                 (Variable "k1" ()) ())
+      --               (Application
+      --                 (Application (Variable "find" ()) (Variable "k" ()) ())
+      --                 (Variable "r" ()) ())
+      --               (If (Application
+      --                     (Application (Variable "less" ()) (Variable "k" ()) ())
+      --                     (Variable "l" ()) ())
+      --                   (Application
+      --                     (Application (Variable "find" ()) (Variable "k" ()) ())
+      --                     (Variable "l" ()) ())
+      --                   (Leaf ()) ()) ()) ()) ()) ()) ()) $
+      --   Declaration "findMin" (BST Integer' Integer' :->: BST Integer' Integer') $
+      --   Definition  "findMin" (Lambda "t"
+      --     (Case
+      --       (Variable "t" ())
+      --       (Leaf ())
+      --       (Node (Variable "l" ()) (Variable "k" ()) (Variable "v" ()) (Variable "r" ()) (),
+      --       Case
+      --         (Variable "l" ())
+      --         (Node (Leaf ()) (Variable "k" ()) (Variable "v" ()) (Leaf ()) ())
+      --         (Node (Variable "l1" ()) (Variable "k1" ()) (Variable "v1" ()) (Variable "r1" ()) (),
+      --         Application (Variable "findMin" ()) (Variable "l1" ()) ()) ()) ()) ()) $
+      --   EndOfProgram)
+      -- , ("examples/bst-properties.pun",
+      --    Property "find-post-present"
+      --             [("k", ()), ("v", ()), ("t", ())]
+      --             (Application
+      --               (Application
+      --                 (Variable "equal" ())
+      --                 (Application
+      --                   (Application (Variable "find" ()) (Variable "k" ()) ())
+      --                   (Application
+      --                     (Application
+      --                       (Application (Variable "insert" ()) (Variable "k" ()) ())
+      --                       (Variable "v" ()) ())
+      --                     (Variable "t" ()) ()) ()) ())
+      --                 (Node (Leaf ())
+      --                       (Variable "k" ())
+      --                       (Variable "v" ())
+      --                       (Leaf ()) ()) ()) $
+      --    Property "find-post-absent"
+      --              [("k", ()), ("t", ())]
+      --              (Application
+      --               (Application
+      --                 (Variable "equal" ())
+      --                 (Application
+      --                   (Application
+      --                     (Variable "find" ())
+      --                     (Variable "k" ()) ())
+      --                   (Application
+      --                     (Application
+      --                       (Variable "delete" ())
+      --                       (Variable "k" ()) ())
+      --                     (Variable "t" ()) ()) ()) ())
+      --                 (Leaf ()) ()) $
+      --    Property "insert-delete-complete"
+      --             [("k", ()), ("t", ())]
+      --             (Case
+      --               (Application
+      --                 (Application
+      --                   (Variable "find" ())
+      --                   (Variable "k" ()) ())
+      --                 (Variable "t" ()) ())
+      --               (Application
+      --                 (Application
+      --                   (Variable "equal" ())
+      --                   (Variable "t" ()) ())
+      --                 (Application
+      --                   (Application
+      --                     (Variable "delete" ())
+      --                     (Variable "k"      ()) ())
+      --                   (Variable "t" ()) ()) ())
+      --                 (Node (Variable "l"  ())
+      --                       (Variable "k1" ())
+      --                       (Variable "v"  ())
+      --                       (Variable "r" ()) (),
+      --                  Application
+      --                   (Application
+      --                     (Variable "equal" ())
+      --                     (Variable "t" ()) ())
+      --                   (Application
+      --                     (Application
+      --                       (Application
+      --                         (Variable "insert" ())
+      --                         (Variable "k" ()) ())
+      --                       (Variable "v" ()) ())
+      --                     (Variable "t" ()) ()) ()) ()) $
+      --    Property "insert-post"
+      --             [("k", ()), ("v", ()), ("t", ()), ("k1", ())]
+      --             (Application
+      --               (Application
+      --                 (Variable "equal" ())
+      --                 (Application
+      --                   (Application
+      --                     (Variable "find" ())
+      --                     (Variable "k1" ()) ())
+      --                   (Application
+      --                     (Application
+      --                       (Application
+      --                         (Variable "insert" ())
+      --                         (Variable "k" ()) ())
+      --                       (Variable "v" ()) ())
+      --                     (Variable "t" ()) ()) ()) ())
+      --                 (If
+      --                   (Application
+      --                     (Application
+      --                       (Variable "equal" ())
+      --                       (Variable "k" ()) ())
+      --                     (Variable "k1" ()) ())
+      --                   (Node (Leaf ())
+      --                         (Variable "k" ())
+      --                         (Variable "v" ())
+      --                         (Leaf ()) ())
+      --                   (Application
+      --                     (Application
+      --                       (Variable "find" ())
+      --                       (Variable "k1" ()) ())
+      --                     (Variable "t" ()) ()) ()) ()) $
+      --    Property "insert-post-same-key"
+      --             [("k", ()), ("v", ()), ("t", ())]
+      --             (Application
+      --               (Application
+      --                 (Application
+      --                   (Application (Variable "insert-post" ()) (Variable "k" ()) ())
+      --                   (Variable "v" ()) ())
+      --                 (Variable "t" ()) ())
+      --               (Variable "k" ()) ()) $
+      --    EndOfProgram)
     ]
 
 -- * Dealing with lore in unit-tests.


### PR DESCRIPTION
This PR adds algebraic data types to the pun programming language.

An algebraic data type with name `D is an `(Algebraic D)`.

It is defined by a list of type constructors, which each have a name C and a list of field types `(TypeConstructor C [Type])`.

A value of type `(Algebraic D)` is a `(Constructor C [Term Type] (Algebraic D))` where C is one of the constructors.