### PR TITLE
Fill type holes with `Integer'`

### DIFF
--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -4,7 +4,6 @@ module TypeInference where
 
 import Syntax
 import Environment
-import Data.Maybe (fromMaybe)
 import Data.Functor ((<&>))
 import Control.Arrow (second)
 import Control.Monad (zipWithM_)
@@ -173,6 +172,11 @@ instance HasSubstitution Type where
 instance HasSubstitution Constraint where
   substitute t i (t0 :=: t1) = substitute t i t0 :=: substitute t i t1
 
+fillTypeHoles :: Substitution -> Substitution
+fillTypeHoles ((i, Variable' j) : rest) = (i, Integer') : (j, Integer') : fillTypeHoles rest
+fillTypeHoles (realizedType     : rest) = realizedType  : fillTypeHoles rest
+fillTypeHoles [                       ] = [ ]
+
 -- Utility functions.
 indexes :: Type -> [Index]
 indexes (Variable' i) = return i
@@ -209,7 +213,9 @@ alphaDef i (TypeConstructor c cs) = second (TypeConstructor c)
 
 -- TODO: Better error handling {^o^}!
 bindings :: [Constraint] -> Substitution
-bindings = fromMaybe (error "type error") . solve
+bindings constraints = case solve constraints of
+  Just cs -> fillTypeHoles cs
+  Nothing -> error "type error"
 
 refine :: Substitution -> (Type -> Type)
 refine s o = refine' s o

--- a/src/TypeInference.hs
+++ b/src/TypeInference.hs
@@ -165,9 +165,9 @@ class HasSubstitution thing where
 
 instance HasSubstitution Type where
   substitute t i (Variable' j) | i == j = t
-  substitute t i (t0 :*: t1)            = substitute t i t0 :*: substitute t i t1
-  substitute t i (t0 :->: t1)           = substitute t i t0 :->: substitute t i t1
-  substitute t i (BST    k v)           = BST (substitute t i k) (substitute t i v)
+  substitute t i (t0  :*:  t1)          = substitute t i t0 :*: substitute t i t1
+  substitute t i (t0  :->: t1)          = substitute t i t0 :->: substitute t i t1
+  substitute t i (BST     k v)          = BST (substitute t i k) (substitute t i v)
   substitute _ _ t0                     = t0
 
 instance HasSubstitution Constraint where

--- a/test/GeneratorGeneratorTests.hs
+++ b/test/GeneratorGeneratorTests.hs
@@ -66,9 +66,8 @@ generateGeneratorTests =
         _          -> True,
     testProperty "generateGenerator t has type Term t forall t." $ whenFail (print "hello") $
     \(TerminatingTerm (term, t)) ->
-      let (t', _, cs) = infer term 0
-          subs        = bindings cs
-          typeOfT'    = annotation (refine subs <$> t')
+      let typedTerm = inferT term
+          typeOfT'  = annotation typedTerm
       in
         equivalent t typeOfT',
     testProperty "Only valid types are generated from a substitution." $
@@ -76,9 +75,8 @@ generateGeneratorTests =
       all (`elem` (fst <$> subs)) (indices t),
     testProperty "generateGenerator generates appropriate type for generated substitution." $
     \(SubstType (_, _, term, canonT)) ->
-      let (t', _, cs) = infer term 0
-          subs'       = bindings cs
-          typeOfT'    = annotation (refine subs' <$> t')
+      let typedTerm = inferT term
+          typeOfT'  = annotation typedTerm
       in
         equivalent canonT typeOfT',
     testProperty "Resolve resolves 'chains' of variables" $


### PR DESCRIPTION
If after solving the type generated constraints there are any remaining type holes, use `Integer'` as the type.

You know that there are type holes if there are any entries in the `Substitution` on the form `(index1, Variable' index2)`, because this means that a type index has just been mapped to a different variable.

If this happens, replace that substitution with `[(index1, Integer'), (index2, Integer')]` and check the rest for any remaining type holes. If not keep the substitution as it was and continue checking the rest.