### PR TITLE
Update GitHub action

### DIFF
--- a/.github/workflows/main-test.yaml
+++ b/.github/workflows/main-test.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell-actions/setup@v2
         with:
           ghc-version:   ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}


### PR DESCRIPTION
Use `haskell-actions/setup` instead of the deprecated `haskell/actions/setup` and bump to v2 (newest).