### PR TITLE
Conditionals in bst benchmark

### DIFF
--- a/benchmark/BST.pun
+++ b/benchmark/BST.pun
@@ -4,12 +4,6 @@ data Unit = Unit .
 
 data Maybe = Nothing | Just [4] .
 
-equal : integer -> integer -> boolean .
-equal m n =
-  if   m <= n
-  then n <= m
-  else false .
-
 not : boolean -> boolean .
 not b = if b then false else true .
 
@@ -18,7 +12,7 @@ and b1 b2 =
   if b1 then b2 else false .
 
 less : integer -> integer -> boolean .
-less m n = and (m <= n) (not (equal m n)) .
+less m n = and (m <= n) (not (m == n)) .
 
 greater : integer -> integer -> boolean .
 greater m n = not (m <= n) .
@@ -84,7 +78,7 @@ find k t =
     case t of
     ; Leaf                  -> Nothing
     ; Node [l1, k1, v1, r1] ->
-        if   (equal k k1)
+        if   (k == k1)
         then Just [v1]
         else if   (greater k k1)
              then (find k r1)
@@ -124,41 +118,41 @@ equalContents t1 t2 = (toList t1) == (toList t2) .
 data List = Empty | Cons [(integer, integer), List] .
 
 listInsert : (integer, integer) -> List -> List .
-listInsert p list =
+listInsert x list =
     case list of
-    ; Empty          -> Cons [p, Empty]
-    ; Cons [q, rest] ->
-        if   (fst p) <= (fst q)
-        then Cons [p, (listInsert q rest)]
-        else Cons [q, (listInsert p rest)] .
+    ; Empty          -> Cons [x, Empty]
+    ; Cons [y, ys] ->
+        if   (fst x) <= (fst y)
+        then Cons [x, (listInsert y ys)]
+        else Cons [y, (listInsert x ys)] .
 
 listDelete : (integer, integer) -> List -> List .
-listDelete p list =
+listDelete x list =
     case list of
     ; Empty         -> Empty
-    ; Cons [q, xs] ->
-        if   (p == q)
-        then xs
-        else Cons [q, (listDelete p xs)] .
+    ; Cons [y, ys] ->
+        if   (x == y)
+        then ys
+        else Cons [y, (listDelete x ys)] .
 
 listUnion : List -> List -> List .
 listUnion l1 l2 =
     case l1 of
     ; Empty          -> l2
-    ; Cons [p, rest] ->
+    ; Cons [x, xs] ->
         case l2 of
-        ; Empty           -> listInsert p l2
-        ; Cons [q, rrest] ->
-            if   (p == q)
-            then listUnion (listDelete p l1) l2
-            else listUnion (listDelete p l1) (listInsert p l2) .
+        ; Empty           -> listInsert x l2
+        ; Cons [y, ys] ->
+            if   (x == y)
+            then listUnion (listDelete x l1) l2
+            else listUnion (listDelete x l1) (listInsert x l2) .
 
 lookup : integer -> List -> Maybe .
 lookup k1 l =
     case l of
     ; Empty        -> Nothing
     ; Cons [(k, v), xs] ->
-        if   (equal k k1)
+        if   (k == k1)
         then Just [v]
         else (lookup k1 xs) .
 
@@ -192,7 +186,7 @@ filter f list =
             else rest .
 
 without : integer -> List -> List .
-without key list = filter (\p -> not (equal (fst p) key)) list .
+without key list = filter (\p -> not ((fst p) == key)) list .
 
 deleteKey : integer -> List -> List .
 deleteKey key list = without key list .
@@ -266,12 +260,12 @@ property find-model k t .
 
 property insert-post k1 v1 t1 k2 .
     if   valid t1
-    then (find k2 (insert k1 v1 t1)) == (if (equal k1 k2) then (Just [v1]) else (find k2 t1))
+    then (find k2 (insert k1 v1 t1)) == (if (k1 == k2) then (Just [v1]) else (find k2 t1))
     else true .
 
 property insert-post-same-key k v t .
     if   valid t
-    then (find k (insert k v t)) == (if (equal k k) then Just [v] else find k t)
+    then (find k (insert k v t)) == (if (k == k) then Just [v] else find k t)
     else true .
 
 property union-post t1 t2 k .
@@ -307,7 +301,7 @@ property insert-delete-complete k t .
 property insert-insert k1 v1 k2 v2 t .
     if   valid t
     then (equalContents (insert k1 v1 (insert k2 v2 t))
-                        (if  (equal  k1 k2)
+                        (if  (k1 == k2)
                         then (insert k1 v1 t)
                         else (insert k2 v2 (insert k1 v1 t))))
     else true .
@@ -315,7 +309,7 @@ property insert-insert k1 v1 k2 v2 t .
 property insert-delete k1 v1 k2 t .
     if valid t
     then (equalContents (insert k1 v1 (delete k2 t))
-                        (if  (equal  k1 k2)
+                        (if  (k1 == k2)
                         then (insert k1 v1 t)
                         else (delete k2 (insert k1 v1 t))))
     else true .

--- a/benchmark/BST.pun
+++ b/benchmark/BST.pun
@@ -23,22 +23,10 @@ less m n = and (m <= n) (not (equal m n)) .
 greater : integer -> integer -> boolean .
 greater m n = not (m <= n) .
 
-equalMaybes : (Maybe, Maybe) -> boolean .
-equalMaybes m =
-    case m of
-    ; (Nothing,   Nothing)   -> true
-    ; (Just [v1], Just [v2]) -> equal v1 v2
-    ; (Nothing,   Just [v3]) -> false
-    ; (Just [v4], Nothing)   -> false .
-
 first : (0, 1) -> 0 .
 first pair =
     case pair of
     ; (x, y) -> x .
-
-equalPairs : (integer, integer) -> (integer, integer) -> boolean .
-equalPairs p1 p2 = and (equal (fst p1) (fst p2))
-                       (equal (snd p1) (snd p2)) .
 
 compose : (0 -> 1) -> (2 -> 0) -> 2 -> 1 .
 compose f g x = f (g x) .
@@ -57,7 +45,7 @@ foldl f acc l =
 
 // ----------------------- BST and operations -----------------------
 
-data BST     = Leaf     | Node [BST, integer, integer, BST] .
+data BST = Leaf | Node [BST, integer, integer, BST] .
 
 nil : BST .
 nil = Leaf .
@@ -69,9 +57,9 @@ insert k1 v1 t =
     ; Node [l2, k2, v2, r2] ->
         if   less k1 k2
         then Node [(insert k1 v1 l2), k2, v2, r2]
-        else if greater k1 k2
+        else if   greater k1 k2
              then Node [l2, k2, v2, (insert k1 v1 r2)]
-             else Node [Leaf, k1, v1, Leaf] .
+             else Node [l2, k1, v1, r2] .
 
 delete : integer -> BST -> BST .
 delete k t =
@@ -102,63 +90,38 @@ find k t =
              then (find k r1)
              else (find k l1) .
 
-validify : BST -> BST .
-validify t =
-    case t of
-    ; Leaf              -> Leaf
-    ; Node [l, k, v, r] -> insert k v (union (validify l) (validify r)) .
-
 valid : BST -> boolean .
 valid t =
     case t of
     ; Leaf              -> true
-    ; Node [l, k, v, r] -> and (and (valid l) (valid r)) (and (lessKeys l) (greaterKeys l)) .
+    ; Node [l, k, v, r] ->
+        (and (and (valid l) (valid r))
+             (and (greaterKeys r k) (lesserKeys l k))) .
 
-lessKeys : BST -> boolean .
-lessKeys t =
+greaterKeys : BST -> integer -> boolean .
+greaterKeys t k =
     case t of
-    ; Leaf                  -> true
-    ; Node [l1, k1, v1, r1] ->
-        case l1 of
-            ; Leaf                  -> true
-            ; Node [l2, k2, v2, r2] ->
-                if   (less k2 k1)
-                then (lessKeys l1)
-                else false .
+    ; Leaf               -> true
+    ; Node [l, k1, v, r] ->
+        (if   (greater k1 k)
+         then (and (greaterKeys r k) (greaterKeys l k))
+         else false) .
 
-greaterKeys : BST -> boolean .
-greaterKeys t =
+lesserKeys : BST -> integer -> boolean .
+lesserKeys t k =
     case t of
-    ; Leaf -> true
-    ; Node [l1, k1, v1, r1] ->
-        case r1 of
-            ; Leaf -> true
-            ; Node [l2, k2, v2, r2] ->
-                if   (greater k2 k1)
-                then (greaterKeys r1)
-                else false .
+    ; Leaf               -> true
+    ; Node [l, k1, v, r] ->
+        (if   (less k1 k)
+         then (and (lesserKeys l k) (lesserKeys r k))
+         else false) .
 
 equalContents : BST -> BST -> boolean .
-equalContents t1 t2 = equalLists (toList t1) (toList t2) .
-
-equalBSTs : BST -> BST -> boolean .
-equalBSTs t1 t2 =
-    case t1 of
-    ; Leaf ->
-        (case t2 of
-        ; Leaf                  -> true
-        ; Node [l1, k1, v1, r1] -> false)
-    ; Node [l2, k2, v2, r2] ->
-        (case t2 of
-        ; Leaf                  -> false
-        ; Node [l3, k3, v3, r3] ->
-            if   (and (equal k3 k2) (equal v2 v3))
-            then true
-            else false) .
+equalContents t1 t2 = (toList t1) == (toList t2) .
 
 // -------------------------- List and operations --------------------------
 
-data List = Empty | Cons [3, List] .
+data List = Empty | Cons [(integer, integer), List] .
 
 listInsert : (integer, integer) -> List -> List .
 listInsert p list =
@@ -174,7 +137,7 @@ listDelete p list =
     case list of
     ; Empty         -> Empty
     ; Cons [q, xs] ->
-        if   (equalPairs p q)
+        if   (p == q)
         then xs
         else Cons [q, (listDelete p xs)] .
 
@@ -186,7 +149,7 @@ listUnion l1 l2 =
         case l2 of
         ; Empty           -> listInsert p l2
         ; Cons [q, rrest] ->
-            if   (equalPairs p q)
+            if   (p == q)
             then listUnion (listDelete p l1) l2
             else listUnion (listDelete p l1) (listInsert p l2) .
 
@@ -204,33 +167,19 @@ unionByFst l1 l2 =
     case l1 of
     ; Empty          -> l2
     ; Cons [p, rest] ->
-        case l2 of
-        ; Empty -> listInsert p l2
-        ; Cons [q, rrest] ->
-            if   (equal (fst p) (fst q))
-            then unionByFst (listDelete p l1) l2
-            else unionByFst (listDelete p l1) (listInsert p l2) .
+        unionByFst (listDelete p l1) (listInsert p l2) .
 
 toList : BST -> List .
 toList t =
     case t of
     ; Leaf              -> Empty
-    ; Node [l, k, v, r] -> listInsert (k, v) (listUnion (toList l) (toList r)) .
+    ; Node [l, k, v, r] -> append (toList l) (Cons [(k, v), (toList r)]) .
 
-equalLists : List -> List -> boolean .
-equalLists l1 l2 =
-    case l1 of
-    ; Empty ->
-        (case l2 of
-        ; Empty        -> true
-        ; Cons [z, zs] -> false)
-    ; Cons [x, xs] ->
-        (case l2 of
-        ; Empty        -> false
-        ; Cons [y, ys] ->
-            if   equalPairs x y
-            then true
-            else false) .
+append : List -> List -> List .
+append xs ys =
+    case xs of
+    ; Empty -> ys
+    ; Cons [x, rest] -> Cons [x, (append rest ys)] .
 
 filter : (0 -> boolean) -> List -> List .
 filter f list =
@@ -274,14 +223,14 @@ property nil-valid .
     valid nil .
 
 property insert-valid k v t .
- if   valid t
- then valid (insert k v t)
- else true .
+    if   valid t
+    then valid (insert k v t)
+    else true .
 
 property delete-valid k v t .
-  if   valid t
-  then valid (delete k t)
-  else true .
+    if   valid t
+    then valid (delete k t)
+    else true .
 
 property union-valid t1 t2 .
     if   and (valid t1) (valid t2)
@@ -291,93 +240,194 @@ property union-valid t1 t2 .
 // ------------------------ Model-based properties ------------------------
 
 property nil-model .
-    equalLists (toList nil) Empty .
+    (toList nil) == Empty .
 
 property insert-model k v t .
-    equalLists (toList (insert k v t))
-               (listInsert (k, v) (deleteKey k (toList t))) .
+    if   valid t
+    then (toList (insert k v t)) == (listInsert (k, v) (deleteKey k (toList t)))
+    else true .
 
 property delete-model k t .
-    equalLists (toList (delete k t))
-               (deleteKey k (toList t)) .
+    if   valid t
+    then (toList (delete k t)) == (deleteKey k (toList t))
+    else true .
 
-// FIXME: Fails
-property union-model t t1 .
-    equalLists (toList (union (validify t) (validify t1)))
-               (sort (unionByFst (toList (validify t)) (toList (validify t1)))) .
+property union-model t1 t2 .
+    if   (and (valid t1) (valid t2))
+    then (toList (union t1 t2)) == (sort (unionByFst (toList t1) (toList t2)))
+    else true .
 
 property find-model k t .
-    equalMaybes ((find k t),
-                (lookup k (toList t))) .
+    if   valid t
+    then (find k t) == (lookup k (toList t))
+    else true .
 
 // ---------------------------- Postconditions ----------------------------
 
 property insert-post k1 v1 t1 k2 .
-    equalMaybes (find k2 (insert k1 v1 t1),
-                (if (equal k1 k2) then (Just [v1]) else (find k2 t1))) .
+    if   valid t1
+    then (find k2 (insert k1 v1 t1)) == (if (equal k1 k2) then (Just [v1]) else (find k2 t1))
+    else true .
 
 property insert-post-same-key k v t .
-    equalMaybes ((find k (insert k v t)),
-                (if (equal k k) then Just [v] else find k t)) .
+    if   valid t
+    then (find k (insert k v t)) == (if (equal k k) then Just [v] else find k t)
+    else true .
 
 property union-post t1 t2 k .
-    equalMaybes ((find k (union t1 t2)),
-                (case find k t1 of
-                ; Just [v] -> Just [v]
-                ; Nothing  ->
-                    (case find k t2 of
-                    ; Just [v1] -> Just [v1]
-                    ; Nothing   -> Nothing))) .
+    if   (and (valid t1) (valid t2))
+    then ((find k (union t1 t2)) == 
+          (case find k t1 of
+           ; Just [v] -> Just [v]
+           ; Nothing  ->
+                (case find k t2 of
+                ; Just [v1] -> Just [v1]
+                ; Nothing   -> Nothing)))
+    else true .
 
 property find-post-present k v t .
-    equalMaybes ((find k (insert k v t)),
-                 (Just [v])) .
+    if   valid t
+    then (find k (insert k v t)) == (Just [v])
+    else true .
 
 property find-post-absent k t .
-    equalMaybes ((find k (delete k t)),
-                Nothing) .
+    if   valid t
+    then (find k (delete k t)) == Nothing
+    else true .
 
 property insert-delete-complete k t .
-    case (find k t) of
-    ; Nothing  -> equalBSTs t (delete k t)
-    ; Just [v] -> equalBSTs t (insert k v t) .
+    if valid t
+    then (case (find k t) of
+          ; Nothing  -> t == (delete k t)
+          ; Just [v] -> t == (insert k v t))
+    else true .
 
 // ------------------------ Metamorphic properties ------------------------
 
 property insert-insert k1 v1 k2 v2 t .
-    equalContents (insert k1 v1 (insert k2 v2 t))
-                  (if  (equal  k1 k2)
-                  then (insert k1 v1 t)
-                  else (insert k2 v2 (insert k1 v1 t))) .
+    if   valid t
+    then (equalContents (insert k1 v1 (insert k2 v2 t))
+                        (if  (equal  k1 k2)
+                        then (insert k1 v1 t)
+                        else (insert k2 v2 (insert k1 v1 t))))
+    else true .
 
 property insert-delete k1 v1 k2 t .
-    equalContents (insert k1 v1 (delete k2 t))
-                  (if  (equal  k1 k2)
-                  then (insert k1 v1 t)
-                  else (delete k2 (insert k1 v1 t))) .
+    if valid t
+    then (equalContents (insert k1 v1 (delete k2 t))
+                        (if  (equal  k1 k2)
+                        then (insert k1 v1 t)
+                        else (delete k2 (insert k1 v1 t))))
+    else true .
 
 property insert-union k v t t1 .
-    equalContents (insert k v (union t t1))
-                  (union (insert k v t) t1) .
+    if  (and (valid t) (valid t1))
+    then (equalContents (insert k v (union t t1))
+                        (union (insert k v t) t1))
+    else true .
+
+property delete-nil k .
+    (delete k nil) == (nil) .
+
+property delete-insert k k1 v1 t .
+    if   valid t
+    then (equalContents (delete k (insert k1 v1 t))
+                        (if  (k == k1)
+                        then (delete k t)
+                        else (insert k1 v1 (delete k t))))
+    else true .
+
+property delete-delete k k1 t .
+    if   valid t
+    then (equalContents (delete k (delete k1 t))
+                        (delete k1 (delete k t)))
+    else true .
+
+property delete-union k t t1 .
+    if   (and (valid t) (valid t1))
+    then (equalContents (delete k (union t t1))
+                        (union (delete k t) (delete k t1)))
+    else true .
+
+property union-nil-1 t .
+    if   valid t
+    then ((union nil t) == t)
+    else true .
+
+property union-nil-2 t .
+    if   valid t
+    then ((union t nil) == t)
+    else true .
+
+property union-delete-insert t t1 k v .
+    if   (and (valid t) (valid t1))
+    then (equalContents (union (delete k t) (insert k v t1))
+                       (insert k v (union t t1)))
+    else true .
+
+property union-union-idem t .
+    if   valid t
+    then (equalContents (union t t) (t))
+    else true .
+
+property union-union-assoc t1 t2 t3 .
+    if   (and (and (valid t1) (valid t2)) (valid t3))
+    then (equalContents (union (union t1 t2) t3)
+                        (union t1 (union t2 t3)))
+    else true .
+
+property find-nil k .
+    find k nil == Nothing .
+
+property find-insert k k1 v1 t .
+    if   valid t
+    then ((find k (insert k1 v1 t)) ==
+          (if k == k1
+           then Just [v1]
+           else find k t))
+    else true .
+
+property find-delete k k1 t .
+    if   valid t
+    then ((find k (delete k1 t)) ==
+          (if   k == k1
+           then Nothing
+           else find k t))
+    else true .
+
+property find-union k t t1 .
+    if   (and (valid t) (valid t1))
+    then ((find k (union t t1)) ==
+          (case (find k t) of
+           ; Nothing  -> find k t1
+           ; Just [v] -> Just [v]))
+    else true .
 
 // -------------------------- Inductive testing --------------------------
 
 property union-nil t .
-    equalBSTs (union nil t)
-              (t) .
+    (union nil t) == t .
 
 property union-insert t t1 k v .
-    equalContents (union (insert k v t) t1)
-                  (insert k v (union t t1)) .
+    if   (and (valid t) (valid t1))
+    then (equalContents (union (insert k v t) t1)
+                        (insert k v (union t t1)))
+    else true .
 
 property insert-complete t .
-    equalBSTs (validify t)
-              (foldl (flip (uncurry insert)) nil (insertions (validify t))) .
+    if   (valid t)
+    then t ==
+         (foldl (flip (uncurry insert)) nil (insertions t))
+    else true .
 
 property insert-complete-for-delete k t .
-    equalBSTs (delete k (validify t))
-              (foldl (flip (uncurry insert)) nil (insertions (delete k (validify t)))) .
+    if   (valid t)
+    then (delete k t) ==
+         (foldl (flip (uncurry insert)) nil (insertions (delete k t)))
+    else true .
 
-property insert-complete-for-union t t1 .
-    equalBSTs (union (validify t) (validify t1))
-              (foldl (flip (uncurry insert)) nil (insertions (union (validify t) (validify t1)))) .
+property insert-complete-for-union t1 t2 .
+    if   (and (valid t1) (valid t2))
+    then (union t1 t2) ==
+         (foldl (flip (uncurry insert)) nil (insertions (union t1 t2)))
+    else true .


### PR DESCRIPTION
**Issue #23 : Conditionals in the BST benchmark**

- Using conditionals to check whether a generated tree is valid instead of "validifying" it
- Properties that didn't work before now are fixed
- Refactoring some function definitions and variable names
- Using built-in equal instead of the equal function
- Added missing metamorphic properties from the end of Hughes' paper