### PR TITLE
Two level generation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -33,7 +33,7 @@ run a = a >>= \what ->
     (Shell         program) -> shell program
 
 numberOfTests :: Integer
-numberOfTests = 50
+numberOfTests = 10000
 
 strengthen :: Monad m => (a, m b) -> m (a, b)
 strengthen (a, mb) = mb <&> (,) a

--- a/src/GeneratorGenerator.hs
+++ b/src/GeneratorGenerator.hs
@@ -35,6 +35,7 @@ generateCanonicalGenerator ds (is, bs, ts) (type1 :->: type2) size =
   do x  <- generateName ts
      t0 <- generateTermGenerator ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) type2 (decrease size)
      return $ Lambda x t0 (type1 :->: type2)
+-- This remaining case is Variable'
 generateCanonicalGenerator ds s tau size = generateTermGenerator ds s tau size
 
 generateTermGenerator :: DataDeclarations -> ProgramConfiguration -> (Type -> (Int -> Gen (Term Type)))

--- a/src/GeneratorGenerator.hs
+++ b/src/GeneratorGenerator.hs
@@ -15,7 +15,7 @@ decrease :: Int -> Int
 decrease size = size `div` 2
 
 generateGenerator :: DataDeclarations -> ProgramConfiguration -> (Type -> Gen (Term Type))
-generateGenerator ds s t = sized (generateGeneratorSized ds s t)
+generateGenerator ds s t = sized (generateCanonicalGenerator ds s t)
 
 generateCanonicalGenerator :: DataDeclarations -> ProgramConfiguration -> (Type -> (Int -> Gen (Term Type)))
 generateCanonicalGenerator _ _ Unit'          _    = return $ Unit Unit'

--- a/src/GeneratorGenerator.hs
+++ b/src/GeneratorGenerator.hs
@@ -33,103 +33,103 @@ generateCanonicalGenerator ds s (Algebraic d) size =
          return $ Constructor c ts (Algebraic d)
 generateCanonicalGenerator ds (is, bs, ts) (type1 :->: type2) size =
   do x  <- generateName ts
-     t0 <- generateGeneratorSized ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) type2 (decrease size)
+     t0 <- generateTermGenerator ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) type2 (decrease size)
      return $ Lambda x t0 (type1 :->: type2)
-generateCanonicalGenerator ds s tau size = generateGeneratorSized ds s tau size
+generateCanonicalGenerator ds s tau size = generateTermGenerator ds s tau size
 
-generateGeneratorSized :: DataDeclarations -> ProgramConfiguration -> (Type -> (Int -> Gen (Term Type)))
-generateGeneratorSized _  _              Unit'    _    = return $ Unit Unit'
-generateGeneratorSized ds s              Integer' 0    = generateGeneratorSized ds s Integer' 1
-generateGeneratorSized _  _              Integer' 1    = flip Number  Integer' <$> arbitrary
-generateGeneratorSized ds s@(is, bs, ts) Integer' size =
+generateTermGenerator :: DataDeclarations -> ProgramConfiguration -> (Type -> (Int -> Gen (Term Type)))
+generateTermGenerator _  _              Unit'    _    = return $ Unit Unit'
+generateTermGenerator ds s              Integer' 0    = generateTermGenerator ds s Integer' 1
+generateTermGenerator _  _              Integer' 1    = flip Number  Integer' <$> arbitrary
+generateTermGenerator ds s@(is, bs, ts) Integer' size =
   frequency $ zip [1..]
     [ flip Number  Integer' <$> arbitrary
-    , do cond  <- generateGeneratorSized ds s Boolean'  (decrease size)
-         t1    <- generateGeneratorSized ds s Integer'  (decrease size)
-         t2    <- generateGeneratorSized ds s Integer'  (decrease size)
+    , do cond  <- generateTermGenerator ds s Boolean'  (decrease size)
+         t1    <- generateTermGenerator ds s Integer'  (decrease size)
+         t2    <- generateTermGenerator ds s Integer'  (decrease size)
          return $ If cond t1 t2 Integer'
-    , do t1    <- generateGeneratorSized ds s Integer'  (decrease size)
-         t2    <- generateGeneratorSized ds s Integer'  (decrease size)
+    , do t1    <- generateTermGenerator ds s Integer'  (decrease size)
+         t2    <- generateTermGenerator ds s Integer'  (decrease size)
          return $ Plus t1 t2 Integer'
-    , do t1    <- generateGeneratorSized ds s Integer' (decrease size)
+    , do t1    <- generateTermGenerator ds s Integer' (decrease size)
          type2 <- generateType is (map snd ts)
-         t2    <- generateGeneratorSized ds s type2    (decrease size)
+         t2    <- generateTermGenerator ds s type2    (decrease size)
          return $ Fst (Pair t1 t2 $ Integer' :*: type2) Integer'
     , do type1 <- generateType is (map snd ts)
-         t1    <- generateGeneratorSized ds s type1    (decrease size)
-         t2    <- generateGeneratorSized ds s Integer' (decrease size)
+         t1    <- generateTermGenerator ds s type1    (decrease size)
+         t2    <- generateTermGenerator ds s Integer' (decrease size)
          return $ Snd (Pair t1 t2 $ type1 :*: Integer') Integer'
     , do argType <- generateType is (map snd ts)
-         f       <- generateGeneratorSized ds s (argType :->: Integer') (decrease size)
-         arg     <- generateGeneratorSized ds s argType (decrease size)
+         f       <- generateTermGenerator ds s (argType :->: Integer') (decrease size)
+         arg     <- generateTermGenerator ds s argType (decrease size)
          return $ Application f arg Integer'
     , do x     <- generateName ts
          type1 <- generateType is (map snd bs)
-         t1    <- generateGeneratorSized ds s type1 (decrease size)
-         t2    <- generateGeneratorSized ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) Integer' (decrease size)
+         t1    <- generateTermGenerator ds s type1 (decrease size)
+         t2    <- generateTermGenerator ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) Integer' (decrease size)
          return $ Let x t1 t2 Integer'
     , do x     <- generateName ts
          -- this is the trivially terminating recursive term, because x does not occur !
-         t1    <- generateGeneratorSized ds (is, filter ((/=x) . fst) bs, ts) Integer' (decrease size)
+         t1    <- generateTermGenerator ds (is, filter ((/=x) . fst) bs, ts) Integer' (decrease size)
          return $ Rec x t1 Integer'
          ]
     ++ ((\a -> (15, return a)) . flip Variable Integer' <$> [ n | (n, t) <- bs , t == Integer' ])
-generateGeneratorSized ds s          Boolean' 0 = generateGeneratorSized ds s Boolean' 1
-generateGeneratorSized _  _          Boolean' 1 = flip Boolean Boolean' <$> arbitrary
-generateGeneratorSized ds s@(is, bs, ts) Boolean' size           =
+generateTermGenerator ds s          Boolean' 0 = generateTermGenerator ds s Boolean' 1
+generateTermGenerator _  _          Boolean' 1 = flip Boolean Boolean' <$> arbitrary
+generateTermGenerator ds s@(is, bs, ts) Boolean' size           =
   frequency $ zip [1..]
     [ flip Boolean  Boolean' <$> arbitrary
-    , do cond  <- generateGeneratorSized ds s Boolean'  (decrease size)
-         t1    <- generateGeneratorSized ds s Boolean'  (decrease size)
-         t2    <- generateGeneratorSized ds s Boolean'  (decrease size)
+    , do cond  <- generateTermGenerator ds s Boolean'  (decrease size)
+         t1    <- generateTermGenerator ds s Boolean'  (decrease size)
+         t2    <- generateTermGenerator ds s Boolean'  (decrease size)
          return $ If cond t1 t2 Boolean'
-    , do t1    <- generateGeneratorSized ds s Integer'  (decrease size)
-         t2    <- generateGeneratorSized ds s Integer'  (decrease size)
+    , do t1    <- generateTermGenerator ds s Integer'  (decrease size)
+         t2    <- generateTermGenerator ds s Integer'  (decrease size)
          return $ Leq t1 t2 Boolean'
     , do type1 <- generateType is (map snd ts) >>= nonFunction
-         t1    <- generateGeneratorSized ds s type1 (decrease size)
-         t2    <- generateGeneratorSized ds s type1 (decrease size)
+         t1    <- generateTermGenerator ds s type1 (decrease size)
+         t2    <- generateTermGenerator ds s type1 (decrease size)
          return $ Equal t1 t2 Boolean'
-    , do t1    <- generateGeneratorSized ds s Boolean' (decrease size)
+    , do t1    <- generateTermGenerator ds s Boolean' (decrease size)
          type2 <- generateType is (map snd ts)
-         t2    <- generateGeneratorSized ds s type2    (decrease size)
+         t2    <- generateTermGenerator ds s type2    (decrease size)
          return $ Fst (Pair t1 t2 $ Boolean' :*: type2) Boolean'
     , do type1 <- generateType is (map snd ts)
-         t1    <- generateGeneratorSized ds s type1    (decrease size)
-         t2    <- generateGeneratorSized ds s Boolean' (decrease size)
+         t1    <- generateTermGenerator ds s type1    (decrease size)
+         t2    <- generateTermGenerator ds s Boolean' (decrease size)
          return $ Snd (Pair t1 t2 $ type1 :*: Boolean') Boolean'
     , do argType <- generateType is (map snd ts)
-         f       <- generateGeneratorSized ds s (argType :->: Boolean') (decrease size)
-         arg     <- generateGeneratorSized ds s argType (decrease size)
+         f       <- generateTermGenerator ds s (argType :->: Boolean') (decrease size)
+         arg     <- generateTermGenerator ds s argType (decrease size)
          return $ Application f arg Boolean'
     , do x     <- generateName ts
          type1 <- generateType is (map snd bs)
-         t1    <- generateGeneratorSized ds s type1 (decrease size)
-         t2    <- generateGeneratorSized ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) Boolean' (decrease size)
+         t1    <- generateTermGenerator ds s type1 (decrease size)
+         t2    <- generateTermGenerator ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) Boolean' (decrease size)
          return $ Let x t1 t2 Boolean'
     , do x     <- generateName ts
          -- this is the trivially terminating recursive term, because x does not occur !
-         t1    <- generateGeneratorSized ds (is, filter ((/=x) . fst) bs, ts) Boolean' (decrease size)
+         t1    <- generateTermGenerator ds (is, filter ((/=x) . fst) bs, ts) Boolean' (decrease size)
          return $ Rec x t1 Boolean'
          ]
     ++ ((\a -> (15, return a)) . flip Variable Boolean' <$> [ n | (n, t) <- bs , t == Boolean' ])
-generateGeneratorSized ds s@(is, _, _) (Variable' index) size   =
-  generateGeneratorSized ds s (resolve index is) (decrease size)
+generateTermGenerator ds s@(is, _, _) (Variable' index) size   =
+  generateTermGenerator ds s (resolve index is) (decrease size)
 -- Todo, generate more interesting things here!
-generateGeneratorSized ds s t@(type1 :*: type2) size =
-  do t1 <- generateGeneratorSized ds s type1 (decrease size)
-     t2 <- generateGeneratorSized ds s type2 (decrease size)
+generateTermGenerator ds s t@(type1 :*: type2) size =
+  do t1 <- generateTermGenerator ds s type1 (decrease size)
+     t2 <- generateTermGenerator ds s type2 (decrease size)
      return $ Pair t1 t2 t
 -- Todo, generate more interesting things here!
-generateGeneratorSized ds (is, bs, ts) (type1 :->: type2) size =
+generateTermGenerator ds (is, bs, ts) (type1 :->: type2) size =
   do x  <- generateName ts
-     t0 <- generateGeneratorSized ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) type2 (decrease size)
+     t0 <- generateTermGenerator ds (is, (x, type1) : filter ((/=x) . fst) bs, ts) type2 (decrease size)
      return $ Lambda x t0 (type1 :->: type2)
-generateGeneratorSized ds s (Algebraic d) size =
+generateTermGenerator ds s (Algebraic d) size =
   oneof (map ctrGen (constructors ds d))
   where
     ctrGen (TypeConstructor c types) =
-      do ts <- mapM (\tau -> generateGeneratorSized ds s tau (decrease size)) types
+      do ts <- mapM (\tau -> generateTermGenerator ds s tau (decrease size)) types
          return $ Constructor c ts (Algebraic d)
 
 resolve :: Index -> LocalIndices -> Type


### PR DESCRIPTION
**Context:**
When generating a type, it's usually only interesting with simple terms.

I.e., if we want an integer, we don't care to generate a function applied to a term that eventually yields a number.

The only case in which we're interested in generating more complex terms is when we are creating a function body.

**Fix:**
Start by generating simple canonical terms when possible, and generate more complex terms only if you ask for it.

Resolves issue #26.