### PR TITLE
Remove pairs

### DIFF
--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -29,16 +29,6 @@ interpret (Leq  t1 t2 a) =
   do m <- interpret t1 >>= number
      n <- interpret t2 >>= number
      return $ Boolean (m <= n) a
-interpret (Pair t1 t2 a) =
-  do v1 <- interpret t1
-     v2 <- interpret t2
-     return $ Pair v1 v2 a
-interpret (Fst p _) =
-  do ts <- interpret p >>= pair
-     return $ fst ts
-interpret (Snd p _) =
-  do ts <- interpret p >>= pair
-     return $ snd ts
 interpret (Equal t0 t1 a) =
   do x <- interpret t0 >>= nonFunction
      y <- interpret t1 >>= nonFunction
@@ -71,10 +61,6 @@ number :: Show a => Term a -> Runtime a Integer
 number (Number n _) = return n
 number t            = error $ "expected an integer, but got a " ++ show t
 
-pair :: Term a -> Runtime a (Term a, Term a)
-pair (Pair t1 t2 _) = return (t1, t2)
-pair _              = error "expected a pair"
-
 function :: Term a -> Runtime a (Term a -> Term a)
 function (Lambda x t a) =
   do notAtTopLevel (x, a)
@@ -93,9 +79,6 @@ substitute x t v = -- computes t[v/x].
     (Plus  t1 t2 a)          -> Plus  (f t1) (f t2)                           a
     (Leq   t1 t2 a)          -> Leq   (f t1) (f t2)                           a
     (Equal t1 t2 a)          -> Equal (f t1) (f t2)                           a
-    (Pair  t1 t2 a)          -> Pair  (f t1) (f t2)                           a
-    (Fst   t1    a)          -> Fst   (f t1)                                  a
-    (Snd   t1    a)          -> Snd   (f t1)                                  a
     (Lambda y t1 a) | x /= y -> Lambda y (f t1)                               a
     (Application t1 t2 a)    -> Application (f t1) (f t2)                     a
     (Let y t1 t2 a)          -> Let y (f t1) ((if x == y then id else f) t2)  a

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -77,12 +77,7 @@ type_ =
   , type'
   ]
   where
-    type'  =
-      choice
-      [ try $ parens $ type'' >>= \t1 -> symbol  "," >> (t1  :*:) <$> type_
-      , type''
-      ]
-    type'' =
+    type' =
       choice
       [ Unit'     <$  unit
       , Integer'  <$  symbol "integer"
@@ -99,7 +94,6 @@ simple =
   , info $ bool_ <&> Boolean
   , info $ Unit  <$ unit
   , info $ name  <&> Variable
-  , info $ try $ parens $ Pair <$> term_ <*> pre "," term_
   , info $ Constructor <$> constructorName <*> option [] (brackets (sepBy term_ (symbol ",")))
   , parens term_
   ]
@@ -116,8 +110,6 @@ term_ =
       cs <- many1 caseBranch
       return $ Case t cs
   , do If <$> pre "if" term_ <*> pre "then" term_ <*> pre "else" term_
-  , pre "fst" (Fst <$> term_)
-  , pre "snd" (Snd <$> term_)
   , pre "\\" $ Lambda <$> name <*> pre "->" term_
   , pre "let" $ Let <$> name <*> pre "=" term_ <*> pre "in" term_
   , pre "rec" $ Rec <$> name <*> pre "." term_
@@ -273,7 +265,6 @@ reserved =
   [ "property"
   , "if", "then", "else"
   , "case", "of"
-  , "fst", "snd"
   , "let", "in", "rec"
   , "data"
   ]

--- a/src/Unification.hs
+++ b/src/Unification.hs
@@ -28,7 +28,6 @@ unify' v              (Variable x   _) = return $ v `substitutes` x
 unify' (Constructor c vs _) (Constructor c' vs' _)
   | c == c' && length vs == length vs'
   = validateUnifiers $ zipWith unify' vs vs'
-unify' (Pair t0 t1 _) (Pair t0' t1' _) = unify' t0 t0' `mappend` unify' t1 t1'
 unify' _ _ = Nothing
 
 validateUnifiers :: [Maybe (Unifier a)] -> Maybe (Unifier a)
@@ -38,7 +37,6 @@ validateUnifiers us
 
 isPattern :: Term a -> Bool
 isPattern (Variable       _ _) = True
-isPattern (Pair       t1 t2 _) = all isPattern [t1, t2]
 isPattern (Constructor _ ts _) = all isPattern ts
 isPattern t                    = canonical t
 
@@ -48,9 +46,6 @@ contains (Constructor _ ts _) x = any (`contains` x) ts
 contains (If t0 t1 t2      _) x = any (`contains` x) [t0, t1, t2]
 contains (Plus  t0 t1      _) x = t0 `contains` x || t1 `contains` x
 contains (Leq   t0 t1      _) x = t0 `contains` x || t1 `contains` x
-contains (Pair  t0 t1      _) x = t0 `contains` x || t1 `contains` x
-contains (Fst   t0         _) x = t0 `contains` x
-contains (Snd   t0         _) x = t0 `contains` x
 contains (Lambda n t0      _) x = n == x || t0 `contains` x
 contains (Let n t1 t2      _) x =
   n   ==        x ||

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -70,11 +70,6 @@ typeParserTests_positive =
   , ("integer -> boolean", Integer' :->: Boolean')
   , ("integer -> integer -> integer", Integer' :->: (Integer' :->: Integer'))
   , ("(integer -> integer) -> integer", (Integer' :->: Integer') :->: Integer')
-  , ("(boolean,boolean)", Boolean' :*: Boolean')
-  , ("(boolean ,boolean)", Boolean' :*: Boolean')
-  , ("(boolean, boolean)", Boolean' :*: Boolean')
-  , ("( boolean,boolean)", Boolean' :*: Boolean')
-  , ("(boolean,boolean )", Boolean' :*: Boolean')
   ]
 
 typeParserTests_negative :: [TestTree]


### PR DESCRIPTION
**Context:**
Resolves issue #31.

We have algebraic data types, so we don't need built-in pairs or pair operations.

**Fix:**
Remove `Pair`, `Fst`, `Snd` and the pair type `:*:`.